### PR TITLE
fix: remove embedded requirement from precompile example

### DIFF
--- a/crates/eryx/Cargo.toml
+++ b/crates/eryx/Cargo.toml
@@ -21,7 +21,6 @@ required-features = ["embedded"]
 
 [[example]]
 name = "precompile"
-required-features = ["embedded"]
 
 [[example]]
 name = "trace_events"

--- a/crates/eryx/examples/precompile.rs
+++ b/crates/eryx/examples/precompile.rs
@@ -13,9 +13,12 @@
 //! 3. Save for embedding in the binary
 //!
 //! Run with preinit (recommended for fastest sessions):
-//!   `cargo run --example precompile --features embedded,preinit --release`
+//!   `cargo run --example precompile --features preinit --release`
 //!
 //! Run without preinit (faster build, slower sessions):
+//!   `cargo run --example precompile --release`
+//!
+//! Run with verification (requires embedded feature, creates chicken-and-egg if .cwasm missing):
 //!   `cargo run --example precompile --features embedded --release`
 
 use std::time::Instant;
@@ -23,6 +26,7 @@ use std::time::Instant;
 #[cfg(feature = "preinit")]
 use std::path::Path;
 
+#[cfg(feature = "embedded")]
 use eryx::session::Session;
 
 fn main() -> anyhow::Result<()> {

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -664,7 +664,6 @@ impl PythonExecutor {
     /// # Errors
     ///
     /// Returns an error if pre-compilation fails.
-    #[cfg(feature = "embedded")]
     pub fn precompile(wasm_bytes: &[u8]) -> std::result::Result<Vec<u8>, Error> {
         let engine = Self::create_engine()?;
         engine
@@ -679,7 +678,6 @@ impl PythonExecutor {
     /// # Errors
     ///
     /// Returns an error if the file cannot be read or pre-compilation fails.
-    #[cfg(feature = "embedded")]
     pub fn precompile_file(
         path: impl AsRef<std::path::Path>,
     ) -> std::result::Result<Vec<u8>, Error> {

--- a/mise.toml
+++ b/mise.toml
@@ -134,14 +134,14 @@ run = "cargo bench --package eryx --all-features -- --save-baseline main"
 [tasks.precompile-eryx-runtime]
 description = "Pre-compile eryx-runtime WASM to native code for faster loading"
 depends = ["build-eryx-runtime"]
-run = "cargo run --example precompile --features embedded --release"
+run = "cargo run --example precompile --release"
 sources = ["crates/eryx-runtime/runtime.wasm"]
 outputs = ["crates/eryx-runtime/runtime.cwasm"]
 
 [tasks.precompile-eryx-runtime-preinit]
 description = "Pre-initialize Python and pre-compile runtime (faster sessions, requires preinit)"
 depends = ["build-eryx-runtime", "build-preinit", "setup-eryx-runtime-tests"]
-run = "cargo run --example precompile --features embedded,preinit --release"
+run = "cargo run --example precompile --features preinit --release"
 sources = [
   "crates/eryx-runtime/runtime.wasm",
   "crates/eryx-wasm-runtime/tests/python-stdlib/encodings/__init__.py",


### PR DESCRIPTION
There was a chicken and egg problem where the precompile example
(which actually does our precompilation) couldn't run because
it required the embedded feature flag, which triggered a build
script which required the output of the example to already exist.
