### PR TITLE
fix(eryx-vfs): fix Windows build by downgrading cap-std to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,22 +212,10 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
 dependencies = [
- "cap-primitives 3.4.5",
- "cap-std 3.4.5",
- "io-lifetimes 2.0.4",
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-fs-ext"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4405110b5afa9876f2e134a140d7ce3541389ebd3439d99ced0b5d78f7331a"
-dependencies = [
- "cap-primitives 4.0.0",
- "cap-std 4.0.0",
- "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -236,8 +224,8 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
- "cap-primitives 3.4.5",
- "cap-std 3.4.5",
+ "cap-primitives",
+ "cap-std",
  "rustix 1.1.2",
  "smallvec",
 ]
@@ -250,31 +238,13 @@ checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
- "io-extras 0.18.4",
- "io-lifetimes 2.0.4",
+ "io-extras",
+ "io-lifetimes",
  "ipnet",
  "maybe-owned",
  "rustix 1.1.2",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2738131575dbd2ca9e8e144a102ba4e534ca726e2446f1e92090a1cc08fe283"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras 0.19.0",
- "io-lifetimes 3.0.1",
- "ipnet",
- "maybe-owned",
- "rustix 1.1.2",
- "rustix-linux-procfs",
- "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -294,21 +264,9 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
 dependencies = [
- "cap-primitives 3.4.5",
- "io-extras 0.18.4",
- "io-lifetimes 2.0.4",
- "rustix 1.1.2",
-]
-
-[[package]]
-name = "cap-std"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d9210de501a941735b489ee5c41501283259ddf3fec9884ace40def0a80a11"
-dependencies = [
- "cap-primitives 4.0.0",
- "io-extras 0.19.0",
- "io-lifetimes 3.0.1",
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
  "rustix 1.1.2",
 ]
 
@@ -319,7 +277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
 dependencies = [
  "ambient-authority",
- "cap-primitives 3.4.5",
+ "cap-primitives",
  "iana-time-zone",
  "once_cell",
  "rustix 1.1.2",
@@ -949,8 +907,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "cap-fs-ext 4.0.0",
- "cap-std 4.0.0",
+ "cap-fs-ext",
+ "cap-std",
  "fs-set-times",
  "system-interface",
  "thiserror 2.0.17",
@@ -1054,7 +1012,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
@@ -1444,18 +1402,8 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-extras"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
-dependencies = [
- "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1463,12 +1411,6 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
-name = "io-lifetimes"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -2567,10 +2509,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
  "bitflags",
- "cap-fs-ext 3.4.5",
- "cap-std 3.4.5",
+ "cap-fs-ext",
+ "cap-std",
  "fd-lock",
- "io-lifetimes 2.0.4",
+ "io-lifetimes",
  "rustix 0.38.44",
  "windows-sys 0.59.0",
  "winx",
@@ -3311,15 +3253,15 @@ dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
- "cap-fs-ext 3.4.5",
+ "cap-fs-ext",
  "cap-net-ext",
  "cap-rand",
- "cap-std 3.4.5",
+ "cap-std",
  "cap-time-ext",
  "fs-set-times",
  "futures",
- "io-extras 0.18.4",
- "io-lifetimes 2.0.4",
+ "io-extras",
+ "io-lifetimes",
  "rustix 1.1.2",
  "system-interface",
  "thiserror 2.0.17",

--- a/crates/eryx-vfs/Cargo.toml
+++ b/crates/eryx-vfs/Cargo.toml
@@ -12,8 +12,8 @@ description = "Virtual filesystem implementation for eryx sandbox"
 anyhow.workspace = true
 async-trait.workspace = true
 bytes = "1"
-cap-fs-ext = "4"
-cap-std = "4"
+cap-fs-ext = "3"
+cap-std = "3"
 fs-set-times = "0.20"
 system-interface = { version = "0.27", features = ["cap_std_impls"] }
 thiserror.workspace = true

--- a/crates/eryx-vfs/src/hybrid_host.rs
+++ b/crates/eryx-vfs/src/hybrid_host.rs
@@ -6,7 +6,8 @@
 
 use std::sync::Arc;
 
-use cap_fs_ext::MetadataExt as CapMetadataExt;
+#[cfg_attr(not(windows), allow(unused_imports))]
+use cap_fs_ext::{DirExt, MetadataExt as CapMetadataExt};
 use system_interface::fs::FileIoExt;
 use wasmtime::component::Resource;
 use wasmtime_wasi_io::streams::{DynInputStream, DynOutputStream};


### PR DESCRIPTION
## Problem

The Windows build was failing with errors like:
```
error[E0599]: no method named `read_at` found for struct `Arc<cap_std::fs::File>`
error[E0599]: no method named `symlink` found for struct `Arc<cap_std::fs::Dir>`
```

## Root Cause

1. **cap-std version mismatch**: The `system-interface` crate's `cap_std_impls` feature only supports cap-std 3.x. Using cap-std 4.x meant the `FileIoExt` trait wasn't implemented for `cap_std::fs::File` on Windows, causing `read_at`/`write_at` methods to be missing.

2. **Missing DirExt import**: On Windows, `cap_std::fs::Dir` doesn't have an inherent `symlink()` method (it's `#[cfg(not(windows))]`). The `DirExt` trait from cap-fs-ext provides this method cross-platform.

## Solution

- Downgrade cap-std and cap-fs-ext from v4 to v3 to match what system-interface supports
- Add `DirExt` import for cross-platform symlink support

## Testing

Tested locally with `cross check -p eryx-vfs --target x86_64-pc-windows-gnu` which now compiles successfully.