### PR TITLE
fix(ci): use uv for Python management on macOS runners

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -291,7 +291,7 @@ jobs:
           uv venv
           uv pip install pytest
           uv pip install dist/*.whl --force-reinstall
-          cd crates/eryx-python && uv run pytest tests/ -v
+          .venv/bin/pytest crates/eryx-python/tests/ -v
 
   # Build wheels for macOS Intel (GitHub runner)
   macos-x86_64:
@@ -366,7 +366,7 @@ jobs:
           uv venv
           uv pip install pytest
           uv pip install dist/*.whl --force-reinstall
-          cd crates/eryx-python && uv run pytest tests/ -v
+          .venv/bin/pytest crates/eryx-python/tests/ -v
 
   # Build wheels for Windows
   windows:


### PR DESCRIPTION
Replace setup-python with astral-sh/setup-uv on macOS jobs to work around unreliable Python installation on namespace runners. The setup-python action was reporting success but the binary path didn't exist, causing builds to fail or fall back to Homebrew's externally managed Python.