### PR TITLE
fix: separate precompile outputs for preinit vs non-preinit variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
           # Use preinit feature for faster sandbox instantiation in downstream jobs
           # (pre-initializes Python interpreter in the snapshot)
           cargo run -p eryx --example precompile --features preinit --release
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
 
       - name: Upload WASM artifacts
         uses: namespace-actions/upload-artifact@v1

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -122,6 +122,8 @@ jobs:
           echo "Pre-compiling WASM for Linux x86_64 with Python pre-initialization..."
           cargo run -p eryx --example precompile --features preinit --release
           ls -la crates/eryx-runtime/runtime.cwasm
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -191,6 +193,8 @@ jobs:
           echo "Pre-compiling WASM for Linux aarch64 with Python pre-initialization..."
           cargo run -p eryx --example precompile --features preinit --release
           ls -la crates/eryx-runtime/runtime.cwasm
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -260,6 +264,8 @@ jobs:
           echo "Pre-compiling WASM for macOS aarch64 with Python pre-initialization..."
           cargo run -p eryx --example precompile --features preinit --release
           ls -la crates/eryx-runtime/runtime.cwasm
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -335,6 +341,8 @@ jobs:
           echo "Pre-compiling WASM for macOS x86_64 with Python pre-initialization..."
           cargo run -p eryx --example precompile --features preinit --release
           ls -la crates/eryx-runtime/runtime.cwasm
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -417,6 +425,8 @@ jobs:
           echo "Pre-compiling WASM for Windows x64 with Python pre-initialization..."
           cargo run -p eryx --example precompile --features preinit --release
           ls -la crates/eryx-runtime/runtime.cwasm
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
 
       - name: Mark cwasm as up-to-date
         shell: bash

--- a/crates/eryx/examples/precompile.rs
+++ b/crates/eryx/examples/precompile.rs
@@ -27,6 +27,16 @@ use std::path::Path;
 use eryx::Session;
 
 fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Parse --output argument
+    let cwasm_path = args
+        .iter()
+        .position(|a| a == "--output")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str())
+        .unwrap_or("crates/eryx-runtime/runtime.cwasm");
+
     let wasm_path = std::env::var("ERYX_WASM_PATH")
         .unwrap_or_else(|_| "crates/eryx-runtime/runtime.wasm".to_string());
 
@@ -95,7 +105,6 @@ fn main() -> anyhow::Result<()> {
     );
 
     // Step 3: Save to disk
-    let cwasm_path = "crates/eryx-runtime/runtime.cwasm";
     println!("\n--- Step 3: Saving pre-compiled WASM ---");
     std::fs::write(cwasm_path, &precompiled)?;
     println!("Saved to: {cwasm_path}");

--- a/mise.toml
+++ b/mise.toml
@@ -157,10 +157,16 @@ else
     fi
 
     if [[ "$WASM_TIME" -gt "$CWASM_TIME" ]]; then
-        echo "⚠️  runtime.wasm is newer than runtime.cwasm - run 'mise run precompile-eryx-runtime'"
+        echo "⚠️  runtime.wasm is newer than runtime.cwasm - run 'mise run precompile-eryx-runtime-preinit'"
     else
-        echo "✓ runtime.cwasm is up-to-date"
+        echo "✓ runtime.cwasm is up-to-date (preinit version)"
     fi
+fi
+
+# Check for non-preinit variant
+CWASM_NO_PREINIT="crates/eryx-runtime/runtime-no-preinit.cwasm"
+if [[ -f "$CWASM_NO_PREINIT" ]]; then
+    echo "runtime-no-preinit.cwasm: $(ls -lh "$CWASM_NO_PREINIT" | awk '{print $5, $6, $7, $8}')"
 fi
 echo ""
 """
@@ -354,6 +360,7 @@ run = """
 echo "Removing WASM artifacts..."
 rm -f crates/eryx-runtime/runtime.wasm
 rm -f crates/eryx-runtime/runtime.cwasm
+rm -f crates/eryx-runtime/runtime-no-preinit.cwasm
 
 echo "Removing prebuilt artifacts..."
 rm -rf crates/eryx-runtime/prebuilt/
@@ -407,17 +414,17 @@ depends = ["precompile-eryx-runtime-preinit"]
 run = "cargo bench --package eryx --all-features -- --save-baseline main"
 
 [tasks.precompile-eryx-runtime]
-description = "Pre-compile eryx-runtime WASM to native code for faster loading"
+description = "Pre-compile eryx-runtime WASM to native code (without Python pre-init)"
 depends = ["build-eryx-runtime"]
-# Note: no --features embedded here - precompile must bootstrap without runtime.cwasm
-run = "cargo run -p eryx --example precompile --release"
+env = { ERYX_PRECOMPILE_BOOTSTRAP = "1" }
+run = "cargo run -p eryx --example precompile --release -- --output crates/eryx-runtime/runtime-no-preinit.cwasm"
 sources = ["crates/eryx-runtime/runtime.wasm"]
-outputs = ["crates/eryx-runtime/runtime.cwasm"]
+outputs = ["crates/eryx-runtime/runtime-no-preinit.cwasm"]
 
 [tasks.precompile-eryx-runtime-preinit]
 description = "Pre-initialize Python and pre-compile runtime (faster sessions, requires preinit)"
 depends = ["build-eryx-runtime", "build-preinit", "setup-eryx-runtime-tests"]
-# Note: no --features embedded here - precompile must bootstrap without runtime.cwasm
+env = { ERYX_PRECOMPILE_BOOTSTRAP = "1" }
 run = "cargo run --example precompile --features preinit --release"
 sources = [
   "crates/eryx-runtime/runtime.wasm",


### PR DESCRIPTION
## Summary

- The two precompile tasks were producing the same output file (`runtime.cwasm`), making it impossible to tell which variant was built
- `precompile-eryx-runtime` now outputs `runtime-no-preinit.cwasm` (rarely used)
- `precompile-eryx-runtime-preinit` continues to output `runtime.cwasm` (main version used everywhere)
- Added `--output` CLI argument to precompile example for custom output paths
- Added `ERYX_PRECOMPILE_BOOTSTRAP` env var to allow bootstrapping without existing `runtime.cwasm`

## Test plan

- [x] Ran `mise run clean-artifacts && mise run setup` - timestamps increase correctly
- [x] Ran `mise run precompile-eryx-runtime` - produces `runtime-no-preinit.cwasm`
- [x] Ran `mise run check-wasm-artifacts` - shows both files
- [ ] CI should pass with the new bootstrap env var

🤖 Generated with [Claude Code](https://claude.ai/code)