### PR TITLE
feat: add CPU feature level configuration for precompilation

### DIFF
--- a/crates/eryx/src/lib.rs
+++ b/crates/eryx/src/lib.rs
@@ -5,8 +5,9 @@
 //! ## Safety
 //!
 //! By default, this crate uses `#![forbid(unsafe_code)]` for maximum safety.
-//! When the `embedded` feature is enabled, this is relaxed to `#![deny(unsafe_code)]`
-//! to allow the unsafe wasmtime deserialization APIs needed for pre-compiled components.
+//! When the `embedded` or `preinit` features are enabled, this is relaxed to
+//! `#![deny(unsafe_code)]` to allow unsafe wasmtime APIs needed for pre-compiled
+//! component loading and CPU feature configuration (e.g., disabling AVX-512).
 //!
 //! Eryx executes Python code in a secure WebAssembly sandbox with:
 //!
@@ -40,8 +41,13 @@
 // - Default: forbid unsafe code entirely
 // - With `embedded` feature: deny unsafe code, but allow it on specific items
 //   that need wasmtime's unsafe deserialization APIs
-#![cfg_attr(not(feature = "embedded"), forbid(unsafe_code))]
-#![cfg_attr(feature = "embedded", deny(unsafe_code))]
+// - With `preinit` feature: deny unsafe code, needed for cranelift CPU feature flags
+//   during precompilation (e.g., disabling AVX-512 for portable builds)
+#![cfg_attr(
+    not(any(feature = "embedded", feature = "preinit")),
+    forbid(unsafe_code)
+)]
+#![cfg_attr(any(feature = "embedded", feature = "preinit"), deny(unsafe_code))]
 
 pub mod cache;
 mod callback;

--- a/mise.toml
+++ b/mise.toml
@@ -424,6 +424,7 @@ outputs = ["crates/eryx-runtime/runtime-no-preinit.cwasm"]
 [tasks.precompile-eryx-runtime-preinit]
 description = "Pre-initialize Python and pre-compile runtime (faster sessions, requires preinit)"
 depends = ["build-eryx-runtime", "build-preinit", "setup-eryx-runtime-tests"]
+# For portable builds (VMs without AVX-512), set ERYX_CPU_FEATURES=x86-64-v3
 env = { ERYX_PRECOMPILE_BOOTSTRAP = "1" }
 run = "cargo run --example precompile --features preinit --release"
 sources = [


### PR DESCRIPTION
## Summary

- Add support for targeting specific x86-64 microarchitecture levels when precompiling WASM to native code
- This allows creating portable binaries that work on VMs without AVX-512 (e.g., Fly.io shared CPUs with AMD EPYC)

## New Environment Variables

**`ERYX_CPU_FEATURES`** - Easy preset levels:
- `x86-64` / `x86-64-v1` - Baseline SSE2 only (maximum compatibility)
- `x86-64-v2` - SSE4.2, POPCNT, SSSE3 (~2008+)
- `x86-64-v3` - AVX2, FMA, BMI1/2, no AVX-512 (~2013+) ← **for Fly.io**
- `x86-64-v4` - AVX-512 (~2017+)
- `native` - Host CPU features (default)

**`ERYX_TARGET`** - Full target triple for cross-compilation

**`ERYX_CRANELIFT_FLAGS`** - Fine-grained Cranelift flag control

## Usage

```bash
# For Fly.io shared CPUs (AMD EPYC with AVX2 but no AVX-512)
ERYX_CPU_FEATURES=x86-64-v3 mise run precompile-eryx-runtime-preinit
```

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)