### PR TITLE
fix: move _eryx_async_import_results init to ERYX_EXEC_INFRASTRUCTURE

### DIFF
--- a/crates/eryx-wasm-runtime/src/python.rs
+++ b/crates/eryx-wasm-runtime/src/python.rs
@@ -811,9 +811,8 @@ import sys, types
 _eryx_async = types.ModuleType('_eryx_async')
 _eryx_async.__doc__ = 'Eryx async runtime - minimal asyncio event loop for Component Model async.'
 
-# Initialize the dict for storing async import results keyed by subtask ID.
-# This must be done before the module code runs so concurrent callbacks work.
-_eryx_async_import_results = {}
+# Note: _eryx_async_import_results is initialized in ERYX_EXEC_INFRASTRUCTURE
+# (which runs after this) to ensure it's in __main__ for PyO3 getattr to find it.
 
 exec(compile(r'''
 """Eryx async runtime - minimal asyncio event loop for Component Model async."""
@@ -1172,6 +1171,11 @@ _eryx_user_globals = {'__builtins__': __builtins__, '__name__': '__main__'}
 # Network async results storage - keyed by subtask ID
 # Used by set_net_result/set_net_bytes_result to store results for Python to retrieve
 _eryx_net_results = {}
+
+# Async import results storage - keyed by subtask ID
+# Used by set_async_import_result/promise_get_result_ for concurrent callback safety
+# This MUST be in __main__ for PyRun_SimpleString and PyO3 getattr to find it
+_eryx_async_import_results = {}
 
 # Import async infrastructure
 import _eryx_async


### PR DESCRIPTION
## Summary

- Moves `_eryx_async_import_results` dict initialization from `ERYX_ASYNC_INJECT_CODE` to `ERYX_EXEC_INFRASTRUCTURE`
- Places it alongside `_eryx_net_results` which is known to work correctly

## Problem

The async callback result dict was being initialized in `ERYX_ASYNC_INJECT_CODE`, but tests showed it wasn't accessible from `__main__` when using preinit snapshots. This caused:
- `test_async_callback_error_message_preserved` to fail with `JSONDecodeError` instead of `RuntimeError`
- `test_subtask_id_keying_directly` to show `has_results_dict: False`

## Solution

Moving the initialization to `ERYX_EXEC_INFRASTRUCTURE` ensures the dict is properly in `__main__.__dict__` and accessible via both:
- `PyRun_SimpleString` (used by `set_async_import_result`)
- PyO3's `getattr` (used by `promise_get_result_`)

## Test plan

- [x] CI tests pass
- [x] `test_async_callback_error_message_preserved` catches `RuntimeError` correctly
- [ ] `test_subtask_id_keying_directly` shows `has_results_dict: True`

🤖 Generated with [Claude Code](https://claude.ai/code)