### PR TITLE
refactor: use typed error variants instead of string matching

### DIFF
--- a/crates/eryx-python/src/error.rs
+++ b/crates/eryx-python/src/error.rs
@@ -49,15 +49,7 @@ pub fn eryx_error_to_py(err: eryx::Error) -> PyErr {
         eryx::Error::Initialization(msg) => InitializationError::new_err(msg),
         eryx::Error::WasmEngine(msg) => InitializationError::new_err(msg),
         eryx::Error::WasmComponent(e) => InitializationError::new_err(e.to_string()),
-        eryx::Error::Execution(msg) => {
-            // Check if this is a timeout error wrapped in an Execution error
-            // The eryx crate converts timeouts to string messages like "Execution timed out after Xms"
-            if msg.contains("timed out") {
-                SandboxTimeoutError::new_err(msg)
-            } else {
-                ExecutionError::new_err(msg)
-            }
-        }
+        eryx::Error::Execution(msg) => ExecutionError::new_err(msg),
         eryx::Error::Callback(e) => ExecutionError::new_err(e.to_string()),
         eryx::Error::ResourceLimit(msg) => ResourceLimitError::new_err(msg),
         eryx::Error::Timeout(duration) => {

--- a/crates/eryx-python/src/session.rs
+++ b/crates/eryx-python/src/session.rs
@@ -260,7 +260,7 @@ impl Session {
                     result
                 })
                 .map(ExecuteResult::from_execution_output)
-                .map_err(|e| eryx_error_to_py(eryx::Error::Execution(e)))
+                .map_err(eryx_error_to_py)
         })
     }
 

--- a/crates/eryx/src/sandbox.rs
+++ b/crates/eryx/src/sandbox.rs
@@ -287,7 +287,7 @@ impl Sandbox {
                     },
                 })
             }
-            Err(error) => Err(Error::Execution(error)),
+            Err(error) => Err(error),
         }
     }
 
@@ -507,11 +507,11 @@ impl Sandbox {
                 })
             }
             Err(error) => {
-                // Check if this was a cancellation
-                if error == "execution cancelled" || cancel_token.is_cancelled() {
+                // Check if this was a cancellation (either from the error or from the token)
+                if matches!(error, Error::Cancelled) || cancel_token.is_cancelled() {
                     Err(Error::Cancelled)
                 } else {
-                    Err(Error::Execution(error))
+                    Err(error)
                 }
             }
         }

--- a/crates/eryx/src/session/in_process.rs
+++ b/crates/eryx/src/session/in_process.rs
@@ -183,7 +183,7 @@ impl<'a> InProcessSession<'a> {
                     },
                 })
             }
-            Err(error) => Err(Error::Execution(error)),
+            Err(error) => Err(error),
         }
     }
 

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -773,7 +773,7 @@ impl<'a> ExecuteBuilder<'a> {
     /// # Errors
     ///
     /// Returns an error if execution fails, times out, or exceeds memory/fuel limits.
-    pub async fn run(self) -> std::result::Result<ExecutionOutput, String> {
+    pub async fn run(self) -> std::result::Result<ExecutionOutput, Error> {
         self.executor
             .execute_internal(
                 &self.code,
@@ -1334,7 +1334,7 @@ impl PythonExecutor {
         cancellation_token: Option<CancellationToken>,
         fuel_limit: Option<u64>,
         #[cfg(feature = "vfs")] vfs_storage: Option<std::sync::Arc<eryx_vfs::InMemoryStorage>>,
-    ) -> std::result::Result<ExecutionOutput, String> {
+    ) -> std::result::Result<ExecutionOutput, Error> {
         // Build callback info for introspection
         let callback_infos: Vec<HostCallbackInfo> = callbacks
             .iter()
@@ -1376,7 +1376,9 @@ impl PythonExecutor {
                     DirPerms::READ,
                     FilePerms::READ,
                 )
-                .map_err(|e| format!("Failed to mount Python stdlib: {e}"))?;
+                .map_err(|e| {
+                    Error::Initialization(format!("Failed to mount Python stdlib: {e}"))
+                })?;
         }
 
         // Set PYTHONPATH for all configured paths (stdlib and/or site-packages)
@@ -1399,7 +1401,7 @@ impl PythonExecutor {
                     DirPerms::READ,
                     FilePerms::READ,
                 )
-                .map_err(|e| format!("Failed to mount {mount_path}: {e}"))?;
+                .map_err(|e| Error::Initialization(format!("Failed to mount {mount_path}: {e}")))?;
         }
 
         let wasi = wasi_builder.build();
@@ -1482,14 +1484,14 @@ impl PythonExecutor {
         let initial_fuel = fuel_limit.unwrap_or(u64::MAX);
         store
             .set_fuel(initial_fuel)
-            .map_err(|e| format!("Failed to set fuel: {e}"))?;
+            .map_err(|e| Error::Initialization(format!("Failed to set fuel: {e}")))?;
 
         // Instantiate from the pre-compiled template (includes Python initialization)
         let bindings = self
             .instance_pre
             .instantiate_async(&mut store)
             .await
-            .map_err(|e| format!("Failed to instantiate component: {e}"))?;
+            .map_err(Error::WasmComponent)?;
 
         tracing::debug!(code_len = code.len(), "Executing Python code");
 
@@ -1571,30 +1573,27 @@ impl PythonExecutor {
             let err_str = format!("{e:?}");
             if err_str.contains("epoch deadline") || err_str.contains("wasm trap: interrupt") {
                 if was_cancelled.load(Ordering::Relaxed) {
-                    "execution cancelled".to_string()
+                    Error::Cancelled
                 } else {
-                    format!(
-                        "Execution timed out after {:?}",
-                        execution_timeout.unwrap_or_default()
-                    )
+                    Error::Timeout(execution_timeout.unwrap_or_default())
                 }
             } else if err_str.contains("fuel") || err_str.contains("out of fuel") {
                 // Calculate how much fuel was consumed before exhaustion
                 let remaining = store.get_fuel().unwrap_or(0);
                 let consumed = initial_fuel.saturating_sub(remaining);
                 let limit = fuel_limit.unwrap_or(u64::MAX);
-                format!(
-                    "Execution ran out of fuel after {} instructions (limit: {})",
-                    consumed, limit
-                )
+                Error::FuelExhausted { consumed, limit }
             } else {
-                format!("WASM execution error: {e:?}")
+                Error::Execution(format!("WASM execution error: {e:?}"))
             }
         })?;
 
-        // wasmtime_result is wasmtime::Result<Result<ExecuteOutput, String>>
+        // wasmtime_result is Result<Result<ExecuteOutput, String>, wasmtime::Error> from the WIT layer
+        // The outer Result is from wasmtime, the inner is the WIT-generated result
         // where ExecuteOutput is the WIT-generated record with stdout and stderr
-        let wit_output = wasmtime_result.map_err(|e| format!("WASM execution error: {e:?}"))??;
+        let wit_output = wasmtime_result
+            .map_err(|e| Error::Execution(format!("WASM execution error: {e:?}")))?
+            .map_err(Error::Execution)?;
 
         // Get peak memory from the store before it's dropped
         let peak_memory_bytes = store.data().memory_tracker.peak_memory_bytes();

--- a/crates/eryx/tests/error_handling.rs
+++ b/crates/eryx/tests/error_handling.rs
@@ -440,8 +440,8 @@ async fn test_execution_timeout_with_infinite_loop() {
     assert!(result.is_err(), "Infinite loop should timeout");
     let error = result.unwrap_err();
     assert!(
-        error.contains("timed out") || error.contains("epoch") || error.contains("interrupt"),
-        "Error should mention timeout/epoch/interrupt: {}",
+        matches!(error, eryx::Error::Timeout(_)),
+        "Error should be Timeout variant: {:?}",
         error
     );
 

--- a/crates/eryx/tests/fuel_limits.rs
+++ b/crates/eryx/tests/fuel_limits.rs
@@ -152,8 +152,8 @@ async fn test_fuel_limit_exceeded_produces_error() {
     assert!(result.is_err(), "Should fail when fuel is exhausted");
     let error = result.unwrap_err();
     assert!(
-        error.contains("fuel") || error.contains("out of fuel"),
-        "Error should mention fuel: {}",
+        matches!(error, eryx::Error::FuelExhausted { .. }),
+        "Error should be FuelExhausted variant: {:?}",
         error
     );
 }


### PR DESCRIPTION
## Summary

- Change `execute` APIs to return `Result<_, Error>` instead of `Result<_, String>`
- Use typed error variants (`Error::Timeout`, `Error::FuelExhausted`, `Error::Cancelled`) instead of constructing string messages
- Remove substring-based timeout detection in `eryx-python` error conversion (the hack that checked `msg.contains("timed out")`)
- Update tests to use pattern matching on error variants instead of string comparisons

## Motivation

The previous approach of returning `String` errors and using substring matching (e.g., `error.contains("timed out")`) was fragile and error-prone:

1. **Fragile string matching**: Error messages could change format, breaking error detection
2. **No compile-time safety**: String comparisons can't be checked by the compiler
3. **Poor API ergonomics**: Callers couldn't use `match` to handle different error types

This refactor leverages the existing typed `Error` enum variants that were already defined but underutilized.

## Changes

### Core error handling (`wasm.rs`, `session/executor.rs`)
- `execute_internal` now returns `Result<_, Error>` 
- Timeout errors return `Error::Timeout(duration)`
- Fuel exhaustion returns `Error::FuelExhausted { consumed, limit }`
- Cancellation returns `Error::Cancelled`

### Sandbox layer (`sandbox.rs`, `in_process.rs`)
- Pass typed errors through instead of wrapping in `Error::Execution`
- Use `matches!(error, Error::Cancelled)` instead of string comparison

### Python bindings (`eryx-python/src/error.rs`)
- Remove the `msg.contains("timed out")` hack
- `Error::Timeout` is now properly mapped to `SandboxTimeoutError`

### Tests (`error_handling.rs`, `fuel_limits.rs`)
- Use pattern matching: `matches!(error, eryx::Error::Timeout(_))`
- Use pattern matching: `matches!(error, eryx::Error::FuelExhausted { .. })`

## Test plan

- [x] All `error_handling` tests pass
- [x] All `fuel_limits` tests pass  
- [x] All `sandbox_callbacks` tests pass
- [x] All `execution_cancellation` tests pass (sequential; some are flaky in parallel due to timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)