### PR TITLE
ci: cancel in-progress runs on new commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to the CI workflow
- When a new commit is pushed to the same branch/PR, any in-progress runs are automatically canceled
- Saves CI minutes by not running redundant jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)