### PR TITLE
ci: switch to self-hosted runner for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Disable incremental compilation so sccache can cache Rust builds
+  CARGO_INCREMENTAL: 0
 
 jobs:
   # Fast check for dependency drift - runs in parallel with build


### PR DESCRIPTION
## Summary
- Replace Namespace cloud runners with self-hosted runner (`ben-3xs`) running on Ryzen 9 7950X
- Remove namespace-specific cache/checkout actions in favor of standard GitHub actions
- Leverage persistent local cargo caches and pre-installed tools (mold, sccache)

## Motivation
Testing whether self-hosted runners can reduce CI costs while maintaining (or improving) build times through:
- Persistent cargo cache (no cold starts)
- 16 cores / 32 threads vs cloud VMs
- sccache wrapper for compilation caching
- Local mold linker already configured

## Caveats
- Jobs run serially on single runner (no parallelism across jobs)
- CI unavailable if machine is offline
- Public repo security: requires approval for external PRs

## Test plan
- [ ] Watch this PR's CI run and compare timing to previous runs
- [ ] Check that all jobs pass
- [ ] Monitor resource usage on ben-3xs during CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)