### PR TITLE
fix(eryx-precompile): remove embedded feature dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "eryx"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "eryx-precompile"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "eryx-python"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "eryx",
  "pyo3",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "eryx-runtime"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "eryx-vfs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "eryx-wasm-runtime"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pyo3",
  "tokio",

--- a/crates/eryx-precompile/Cargo.toml
+++ b/crates/eryx-precompile/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4", features = ["derive"] }
-eryx = { workspace = true, features = ["preinit", "embedded"] }
+eryx = { workspace = true, features = ["preinit"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/eryx/src/sandbox.rs
+++ b/crates/eryx/src/sandbox.rs
@@ -622,10 +622,10 @@ enum WasmSource {
     /// Path to a WASM component file (will be compiled at load time).
     File(std::path::PathBuf),
     /// Pre-compiled component bytes (skip compilation, unsafe).
-    #[cfg(feature = "embedded")]
+    #[cfg(any(feature = "embedded", feature = "preinit"))]
     PrecompiledBytes(Vec<u8>),
     /// Path to a pre-compiled component file (skip compilation, unsafe).
-    #[cfg(feature = "embedded")]
+    #[cfg(any(feature = "embedded", feature = "preinit"))]
     PrecompiledFile(std::path::PathBuf),
     /// Use the embedded pre-compiled runtime (safe, fast).
     #[cfg(feature = "embedded")]
@@ -888,7 +888,7 @@ impl<S> SandboxBuilder<state::Needs, S> {
     ///         .build()?
     /// };
     /// ```
-    #[cfg(feature = "embedded")]
+    #[cfg(any(feature = "embedded", feature = "preinit"))]
     #[must_use]
     #[allow(unsafe_code)]
     pub unsafe fn with_precompiled_bytes(
@@ -931,7 +931,7 @@ impl<S> SandboxBuilder<state::Needs, S> {
     ///         .build()?
     /// };
     /// ```
-    #[cfg(feature = "embedded")]
+    #[cfg(any(feature = "embedded", feature = "preinit"))]
     #[must_use]
     #[allow(unsafe_code)]
     pub unsafe fn with_precompiled_file(
@@ -1486,7 +1486,7 @@ impl SandboxBuilder<state::Has, state::Has> {
             WasmSource::Bytes(bytes) => PythonExecutor::from_binary(bytes)?,
             WasmSource::File(path) => PythonExecutor::from_file(path)?,
 
-            #[cfg(feature = "embedded")]
+            #[cfg(any(feature = "embedded", feature = "preinit"))]
             WasmSource::PrecompiledBytes(bytes) => {
                 // SAFETY: User is responsible for only using trusted pre-compiled bytes.
                 // The `with_precompiled_bytes` method is already marked unsafe, so the
@@ -1497,7 +1497,7 @@ impl SandboxBuilder<state::Has, state::Has> {
                 }
             }
 
-            #[cfg(feature = "embedded")]
+            #[cfg(any(feature = "embedded", feature = "preinit"))]
             WasmSource::PrecompiledFile(path) => {
                 // SAFETY: User is responsible for only using trusted pre-compiled files.
                 // The `with_precompiled_file` method is already marked unsafe, so the


### PR DESCRIPTION
## Summary
- Remove `embedded` feature from eryx-precompile dependencies (fixes circular dep)
- Extend `with_precompiled_file` and `from_precompiled_file` APIs to work with `preinit` feature

## Problem
eryx-precompile is a build tool that creates `runtime.cwasm`, but it was depending on `eryx` with the `embedded` feature which requires `runtime.cwasm` to exist - a circular dependency.

## Solution
1. Remove `embedded` feature from eryx-precompile's dependencies
2. Extend the precompiled loading APIs (`with_precompiled_file`, `from_precompiled_file`, etc.) to work with `preinit` feature, not just `embedded`
3. This allows eryx-precompile to verify the cwasm it creates without needing the embedded runtime

Both `embedded` and `preinit` features enable unsafe code, so there's no safety regression.

## Test plan
- [ ] CI passes
- [ ] After merge, re-tag v0.3.0 and release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)