### PR TITLE
fix(dist): use precise-builds to avoid feature unification

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -11,3 +11,7 @@ ci = "github"
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Build packages individually instead of using --workspace
+# This avoids feature unification issues where other packages (like eryx-python)
+# enable features that require build-time artifacts we don't have
+precise-builds = true


### PR DESCRIPTION
## Summary
- Add `precise-builds = true` to cargo-dist config
- This makes dist use `--package=eryx-precompile` instead of `--workspace`
- Avoids feature unification where eryx-python's `embedded` dependency caused build failures

## Test plan
- [x] Tested locally: `dist build --artifacts=local --target=x86_64-unknown-linux-gnu` succeeds
- [ ] CI passes
- [ ] After merge, recreate v0.3.0 tag to trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)