### PR TITLE
fix(ci): add Rust cache to book-tests with targeted clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,9 +385,11 @@ jobs:
 
       - uses: ./.github/actions/mark-wasm-current
 
-      # Note: We intentionally don't use the Rust cache here because the shared
-      # cache contains many feature combinations from check-all-features, causing
-      # "multiple candidates for rmeta dependency" errors in mdbook test.
+      - name: Configure Rust cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: rust
+
       - uses: ./.github/actions/setup-rust
 
       - name: Install mdbook tools
@@ -396,7 +398,11 @@ jobs:
           cargo binstall -y mdbook-langtabs
 
       - name: Build project
-        run: cargo build -p eryx --features embedded
+        run: |
+          # Clean eryx packages to avoid "multiple rmeta candidates" from cached
+          # feature combinations (e.g., from check-all-features job)
+          cargo clean -p eryx -p eryx-runtime 2>/dev/null || true
+          cargo build -p eryx --features embedded
 
       - name: Test Rust code blocks
         run: mdbook test -L ../target/debug/deps


### PR DESCRIPTION
## Summary

- Re-enable namespace Rust cache for book-tests job
- Add `cargo clean -p eryx -p eryx-runtime` before build to avoid "multiple rmeta candidates" errors

## Problem

PR #60 removed the Rust cache from book-tests because the shared cache contained many feature combinations from check-all-features, causing linker errors. However, this meant dependencies had to be rebuilt from scratch.

## Solution

Keep the cache for dependencies (tokio, serde, wasmtime, etc.) but clean the eryx packages specifically before building. This gives us:

- Fast dependency loading from cache
- Clean build of eryx with only the features we need
- No multiple rmeta candidate errors

## Test plan

- [ ] CI passes
- [ ] Book tests complete faster than without cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)