### PR TITLE
feat(python): add CLI for running sandboxed Python from the terminal

### DIFF
--- a/crates/eryx-python/pyproject.toml
+++ b/crates/eryx-python/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Topic :: Software Development :: Interpreters",
 ]
 
+[project.scripts]
+eryx = "eryx.__main__:main"
+
 [project.optional-dependencies]
 dev = ["pytest", "pytest-asyncio", "mypy", "requests", "httpx"]
 

--- a/crates/eryx-python/python/eryx/__main__.py
+++ b/crates/eryx-python/python/eryx/__main__.py
@@ -1,0 +1,272 @@
+"""Eryx CLI: run Python code in a WebAssembly sandbox.
+
+Usage:
+    python -m eryx                     # Interactive REPL
+    python -m eryx script.py           # Execute a file
+    python -m eryx -c 'print("hi")'   # Execute a string
+    echo 'print("hi")' | python -m eryx -  # Execute from stdin
+
+Examples:
+    uvx --with pyeryx eryx -c 'import sys; print(sys.version)'
+    uvx --with pyeryx eryx --timeout 5000 -c 'print("hello")'
+    uvx --with pyeryx eryx --net --allow-host '*.example.com' -c 'import urllib.request; ...'
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+
+import eryx
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="eryx",
+        description="Run Python code in an Eryx WebAssembly sandbox.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              eryx                              interactive REPL
+              eryx script.py                    execute a file
+              eryx -c 'print("hello")'          execute a string
+              echo 'print(1+1)' | eryx -        read code from stdin
+              eryx --timeout 5000 script.py     set execution timeout
+              eryx --net -c 'import requests'   enable network access
+        """),
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {eryx.__version__}",
+    )
+
+    # --- code source (mutually exclusive) ---
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "-c",
+        metavar="CODE",
+        dest="command",
+        help="execute CODE and exit",
+    )
+    source.add_argument(
+        "script",
+        nargs="?",
+        default=None,
+        help="Python file to execute (use '-' for stdin)",
+    )
+
+    # --- resource limits ---
+    limits = parser.add_argument_group("resource limits")
+    limits.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        metavar="MS",
+        help="execution timeout in milliseconds (default: 30000)",
+    )
+    limits.add_argument(
+        "--max-memory",
+        type=int,
+        default=None,
+        metavar="BYTES",
+        help="maximum memory in bytes (default: 128MB)",
+    )
+
+    # --- networking ---
+    net = parser.add_argument_group("networking")
+    net.add_argument(
+        "--net",
+        action="store_true",
+        default=False,
+        help="enable network access",
+    )
+    net.add_argument(
+        "--allow-host",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="allow network access to hosts matching PATTERN (implies --net)",
+    )
+
+    # --- filesystem ---
+    fs = parser.add_argument_group("filesystem")
+    fs.add_argument(
+        "-v",
+        "--volume",
+        action="append",
+        default=[],
+        metavar="SRC:DST",
+        help="mount host directory SRC at sandbox path DST (not yet implemented)",
+    )
+
+    return parser
+
+
+def _make_resource_limits(args: argparse.Namespace) -> eryx.ResourceLimits | None:
+    if args.timeout is None and args.max_memory is None:
+        return None
+    limits = eryx.ResourceLimits()
+    if args.timeout is not None:
+        limits.execution_timeout_ms = args.timeout
+    if args.max_memory is not None:
+        limits.max_memory_bytes = args.max_memory
+    return limits
+
+
+def _make_net_config(args: argparse.Namespace) -> eryx.NetConfig | None:
+    if not args.net and not args.allow_host:
+        return None
+    config = eryx.NetConfig.permissive()
+    for pattern in args.allow_host:
+        config.allow_host(pattern)
+    return config
+
+
+def _run_once(code: str, args: argparse.Namespace) -> int:
+    """Execute code in a stateless Sandbox and print the result."""
+    limits = _make_resource_limits(args)
+    net = _make_net_config(args)
+    kwargs = {}
+    if limits is not None:
+        kwargs["resource_limits"] = limits
+    if net is not None:
+        kwargs["network"] = net
+
+    sandbox = eryx.Sandbox(**kwargs)
+    try:
+        result = sandbox.execute(code)
+    except eryx.TimeoutError as exc:
+        print(f"eryx: timeout: {exc}", file=sys.stderr)
+        return 1
+    except eryx.ResourceLimitError as exc:
+        print(f"eryx: resource limit: {exc}", file=sys.stderr)
+        return 1
+    except eryx.ExecutionError as exc:
+        print(f"{exc}", file=sys.stderr)
+        return 1
+    except eryx.EryxError as exc:
+        print(f"eryx: {exc}", file=sys.stderr)
+        return 1
+
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+        if not result.stdout.endswith("\n"):
+            sys.stdout.write("\n")
+    return 0
+
+
+def _repl(args: argparse.Namespace) -> int:
+    """Run an interactive REPL using Session for persistent state."""
+    kwargs = {}
+    limits = _make_resource_limits(args)
+    if limits is not None:
+        kwargs["execution_timeout_ms"] = limits.execution_timeout_ms
+
+    session = eryx.Session(**kwargs)
+
+    print(f"Eryx {eryx.__version__} (sandbox REPL)")
+    print('Type "exit()" or Ctrl-D to quit.')
+
+    buf: list[str] = []
+    prompt = ">>> "
+
+    while True:
+        try:
+            line = input(prompt)
+        except (EOFError, KeyboardInterrupt):
+            if buf:
+                buf.clear()
+                prompt = ">>> "
+                print()
+                continue
+            print()
+            break
+
+        if not buf and line.strip() == "exit()":
+            break
+
+        buf.append(line)
+
+        # Detect multi-line blocks: if the line ends with ':', or we're
+        # already in a continuation and the line is indented / blank,
+        # keep collecting.
+        if line.rstrip().endswith(":") or (len(buf) > 1 and (line.startswith((" ", "\t")) or line.strip() == "")):
+            prompt = "... "
+            continue
+
+        code = "\n".join(buf)
+        buf.clear()
+        prompt = ">>> "
+
+        try:
+            result = session.execute(code)
+        except eryx.TimeoutError as exc:
+            print(f"TimeoutError: {exc}", file=sys.stderr)
+            continue
+        except eryx.ResourceLimitError as exc:
+            print(f"ResourceLimitError: {exc}", file=sys.stderr)
+            continue
+        except eryx.ExecutionError as exc:
+            print(f"{exc}", file=sys.stderr)
+            continue
+        except eryx.EryxError as exc:
+            print(f"EryxError: {exc}", file=sys.stderr)
+            continue
+
+        if result.stdout:
+            sys.stdout.write(result.stdout)
+            if not result.stdout.endswith("\n"):
+                sys.stdout.write("\n")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.volume:
+        print(
+            "eryx: --volume/-v is not yet implemented",
+            file=sys.stderr,
+        )
+        return 1
+
+    # -c CODE
+    if args.command is not None:
+        return _run_once(args.command, args)
+
+    # script file or stdin
+    if args.script is not None:
+        if args.script == "-":
+            code = sys.stdin.read()
+        else:
+            try:
+                with open(args.script) as f:
+                    code = f.read()
+            except FileNotFoundError:
+                print(f"eryx: {args.script}: No such file", file=sys.stderr)
+                return 1
+            except OSError as exc:
+                print(f"eryx: {args.script}: {exc}", file=sys.stderr)
+                return 1
+        return _run_once(code, args)
+
+    # interactive REPL (only if stdin is a terminal)
+    if sys.stdin.isatty():
+        return _repl(args)
+
+    # piped input without '-' — read stdin anyway
+    code = sys.stdin.read()
+    if code.strip():
+        return _run_once(code, args)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/eryx-python/tests/test_cli.py
+++ b/crates/eryx-python/tests/test_cli.py
@@ -1,0 +1,154 @@
+"""Tests for the eryx CLI (__main__.py)."""
+
+import subprocess
+import sys
+import textwrap
+from unittest.mock import patch
+
+import pytest
+
+from eryx.__main__ import main
+
+
+class TestCliCommandExecution:
+    """Tests for -c flag (command execution)."""
+
+    def test_execute_simple_command(self):
+        result = main(["-c", 'print("hello")'])
+        assert result == 0
+
+    def test_execute_command_with_output(self, capsys):
+        main(["-c", 'print("hello world")'])
+        captured = capsys.readouterr()
+        assert "hello world" in captured.out
+
+    def test_execute_multiline_command(self, capsys):
+        main(["-c", "x = 2 + 3\nprint(x)"])
+        captured = capsys.readouterr()
+        assert "5" in captured.out
+
+    def test_execute_command_with_error(self, capsys):
+        result = main(["-c", "raise ValueError('boom')"])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "ValueError" in captured.err
+
+    def test_execute_empty_command(self):
+        result = main(["-c", ""])
+        assert result == 0
+
+
+class TestCliScriptExecution:
+    """Tests for script file execution."""
+
+    def test_execute_script_file(self, tmp_path, capsys):
+        script = tmp_path / "test.py"
+        script.write_text('print("from file")')
+        result = main([str(script)])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "from file" in captured.out
+
+    def test_execute_nonexistent_file(self, capsys):
+        result = main(["/nonexistent/path.py"])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "No such file" in captured.err
+
+    def test_execute_multiline_script(self, tmp_path, capsys):
+        script = tmp_path / "multi.py"
+        script.write_text(textwrap.dedent("""\
+            for i in range(3):
+                print(f"line {i}")
+        """))
+        result = main([str(script)])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "line 0" in captured.out
+        assert "line 1" in captured.out
+        assert "line 2" in captured.out
+
+    def test_execute_stdin_dash(self, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = 'print("from stdin")'
+            result = main(["-"])
+            assert result == 0
+            captured = capsys.readouterr()
+            assert "from stdin" in captured.out
+
+
+class TestCliResourceLimits:
+    """Tests for resource limit flags."""
+
+    def test_timeout_flag(self, capsys):
+        # A very short timeout should cause a timeout error for slow code
+        result = main(["--timeout", "1", "-c", "import time; time.sleep(10)"])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "timeout" in captured.err.lower()
+
+    def test_timeout_flag_sufficient(self, capsys):
+        result = main(["--timeout", "30000", "-c", 'print("ok")'])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ok" in captured.out
+
+
+class TestCliNetworking:
+    """Tests for networking flags."""
+
+    def test_net_flag_accepted(self, capsys):
+        # Just verify the flag is accepted and code runs
+        result = main(["--net", "-c", 'print("net enabled")'])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "net enabled" in captured.out
+
+    def test_allow_host_implies_net(self, capsys):
+        result = main(["--allow-host", "*.example.com", "-c", 'print("ok")'])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ok" in captured.out
+
+
+class TestCliVolume:
+    """Tests for volume mount flag."""
+
+    def test_volume_flag_not_implemented(self, capsys):
+        result = main(["-v", "/tmp:/data", "-c", 'print("hi")'])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "not yet implemented" in captured.err
+
+
+class TestCliVersion:
+    """Tests for --version flag."""
+
+    def test_version_flag(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "eryx" in captured.out
+
+
+class TestCliMutualExclusion:
+    """Tests for mutually exclusive arguments."""
+
+    def test_c_and_script_mutually_exclusive(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["-c", "print(1)", "script.py"])
+        assert exc_info.value.code != 0
+
+
+class TestCliPipedInput:
+    """Tests for piped stdin behavior."""
+
+    def test_piped_stdin_without_dash(self, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            mock_stdin.read.return_value = 'print("piped")'
+            result = main([])
+            assert result == 0
+            captured = capsys.readouterr()
+            assert "piped" in captured.out


### PR DESCRIPTION
## Summary

Adds a CLI to the `pyeryx` package so users can run sandboxed Python directly from the terminal.

- `python -m eryx` — interactive REPL with persistent state
- `python -m eryx -c 'code'` — one-shot execution  
- `python -m eryx script.py` — execute a file
- `echo 'code' | python -m eryx -` — read from stdin
- `uvx --with pyeryx eryx ...` — works as a standalone tool

Also adds flags for resource limits (`--timeout`, `--max-memory`), networking (`--net`, `--allow-host`), and a placeholder for future volume mounts (`-v`/`--volume`).

Closes #59

## Changes

- New `crates/eryx-python/python/eryx/__main__.py` — CLI implementation with REPL, command execution, script execution, and stdin piping
- Updated `crates/eryx-python/pyproject.toml` — added `[project.scripts]` entry point (`eryx = "eryx.__main__:main"`)
- New `crates/eryx-python/tests/test_cli.py` — 17 tests covering all CLI modes and flags

## Testing

All 17 new CLI tests pass. All 99 existing tests pass with no regressions.

```
tests/test_cli.py ............ 17 passed
tests/test_sandbox.py ........ 60 passed  
tests/test_session.py ........ 39 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)