### PR TITLE
chore(python): add mise tasks for building and testing Python package

### DIFF
--- a/crates/eryx-python/mise.toml
+++ b/crates/eryx-python/mise.toml
@@ -1,0 +1,112 @@
+# =============================================================================
+# Python bindings tasks (pyeryx via maturin + uv)
+# =============================================================================
+#
+# Usage:
+#   cd crates/eryx-python
+#   mise run build       # Build the Python extension (maturin develop)
+#   mise run test        # Build + run pytest
+#   mise run test-only   # Run pytest without rebuilding
+#   mise run clean       # Remove build artifacts
+#
+# The WASM runtime and precompiled artifacts are built via root mise tasks.
+# These are slow (~minutes) and cached aggressively — they only rebuild when
+# source files change.
+
+[tools]
+uv = "latest"
+
+# =============================================================================
+# WASM runtime (delegates to root)
+# =============================================================================
+
+[tasks.wasm-build]
+description = "Build eryx WASM runtime (delegates to root mise task)"
+sources = [
+  "../eryx-wasm-runtime/src/**/*.rs",
+  "../eryx-wasm-runtime/Cargo.toml",
+  "../eryx-runtime/wit/**/*.wit",
+]
+outputs = ["../eryx-runtime/runtime.wasm"]
+run = "cd ../.. && mise run build-eryx-runtime"
+
+[tasks.precompile]
+description = "Precompile WASM with Python pre-init (delegates to root mise task)"
+depends = ["wasm-build"]
+sources = ["../eryx-runtime/runtime.wasm"]
+outputs = ["../eryx-runtime/runtime.cwasm"]
+run = "cd ../.. && mise run precompile-eryx-runtime-preinit"
+
+# =============================================================================
+# Python environment
+# =============================================================================
+
+[tasks.sync]
+description = "Create venv and install dev dependencies with uv"
+sources = ["pyproject.toml", "uv.lock"]
+outputs = [".venv/pyvenv.cfg"]
+run = "uv sync --frozen --all-extras"
+
+# =============================================================================
+# Build
+# =============================================================================
+
+[tasks.build]
+description = "Build Python extension with maturin (release mode)"
+depends = ["precompile", "sync"]
+sources = [
+  "src/**/*.rs",
+  "Cargo.toml",
+  "pyproject.toml",
+  "python/**/*.py",
+  "../eryx-runtime/runtime.cwasm",
+  "../eryx-runtime/prebuilt/*.so.zst",
+]
+outputs = [".venv/lib/**/eryx/_eryx.abi3.so"]
+run = "uv run maturin develop --release"
+
+# =============================================================================
+# Test
+# =============================================================================
+
+[tasks.test]
+description = "Build and run Python tests"
+depends = ["build"]
+run = "uv run pytest tests/ -v"
+
+[tasks.test-only]
+description = "Run Python tests without rebuilding (assumes extension is up-to-date)"
+depends = ["sync"]
+run = "uv run pytest tests/ -v"
+
+[tasks.examples]
+description = "Run Python examples"
+depends = ["build"]
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+for f in examples/*.py; do
+  echo "=== $(basename "$f") ==="
+  uv run python "$f"
+  echo ""
+done
+"""
+
+# =============================================================================
+# Utilities
+# =============================================================================
+
+[tasks.typecheck]
+description = "Run mypy type checking"
+depends = ["build"]
+run = "uv run mypy python/eryx --ignore-missing-imports"
+
+[tasks.clean]
+description = "Remove build artifacts"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+rm -rf target/
+rm -rf .venv/
+echo "Cleaned Python build artifacts"
+"""

--- a/mise.toml
+++ b/mise.toml
@@ -41,13 +41,9 @@ depends = ["precompile-eryx-runtime-preinit"]
 run = "cargo nextest run --workspace --features embedded"
 
 [tasks.test-python]
-description = "Run Python binding tests"
-depends = ["precompile-eryx-runtime-preinit"]
+description = "Run Python binding tests (delegates to crates/eryx-python/mise.toml)"
 dir = "crates/eryx-python"
-run = """
-maturin develop --release
-.venv/bin/pytest tests/ -v
-"""
+run = "mise run test"
 
 [tasks.test-all]
 description = "Run tests with all features"


### PR DESCRIPTION
## Summary

- Adds a monorepo-style `crates/eryx-python/mise.toml` with tasks for building and testing the Python package using `uv` and `maturin`
- Delegates WASM runtime builds to root mise tasks with source/output caching to avoid slow cwasm rebuilds
- Updates root `test-python` task to delegate to the new sub-mise.toml

## Tasks provided

| Task | Description |
|------|-------------|
| `sync` | Create venv and install dev dependencies with uv |
| `build` | Build Python extension with maturin (release mode) |
| `test` | Build and run pytest |
| `test-only` | Run pytest without rebuilding |
| `examples` | Run all Python examples |
| `typecheck` | Run mypy type checking |
| `clean` | Remove build artifacts |
| `wasm-build` | Delegates to root `build-eryx-runtime` |
| `precompile` | Delegates to root `precompile-eryx-runtime-preinit` |

## Usage

```bash
cd crates/eryx-python
mise run test        # Full build + test pipeline
mise run test-only   # Quick test (skip rebuild)
mise run build       # Just build the extension
```

## Test plan

- [x] `mise run sync` creates venv with all dev dependencies
- [x] `mise run build` builds extension via maturin develop --release
- [x] `mise run test` passes all 212 Python tests
- [x] `mise run test-only` runs pytest without rebuild
- [x] `mise run examples` runs all Python examples
- [x] Root `mise run test-python` correctly delegates to sub-mise.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)