### PR TITLE
ci: deploy browser demo to Cloudflare Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,9 @@ jobs:
             --map 'report-trace=./shims/callbacks.js#reportTrace' \
             --map 'wasi:sockets/*=./shims/sockets.js#*'
 
+      - name: Install demo dependencies
+        run: npm ci --prefix js/eryx-sandbox
+
       - name: Patch JS for jco bugs
         working-directory: js
         run: node patch-jco.cjs
@@ -586,7 +589,6 @@ jobs:
           cp -r js/eryx-sandbox/shims deploy/
 
           # preview2-shim (referenced by import map in demo.html)
-          npm ci --prefix js/eryx-sandbox
           cp -r js/eryx-sandbox/node_modules/@bytecodealliance deploy/node_modules/
 
       - name: Deploy to demo branch


### PR DESCRIPTION
## Summary
- Adds a `deploy-demo` CI job that builds the JS demo (preinit → jco transpile → patch) and pushes built artifacts to a `demo` branch
- Cloudflare Pages Git integration watches the `demo` branch to deploy to `demo.eryx.run`
- No API tokens needed — uses the same pattern as augurs (dashboard-configured Git integration)

## Setup needed after merge
1. Configure Cloudflare Pages project in the dashboard:
   - Connect `eryx-org/eryx` repo
   - Production branch: `demo`
   - Build command: _(none)_
   - Build output directory: `/`
2. Add custom domain `demo.eryx.run` in Cloudflare Pages project settings
3. DNS: CNAME `demo` → `eryx-demo.pages.dev`

## Test plan
- [ ] Merge to main and verify the `demo` branch is created with built artifacts
- [ ] Configure Cloudflare Pages and verify demo.eryx.run loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)