### PR TITLE
fix(deploy): use vendor/ instead of node_modules/ for CF Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,7 +569,7 @@ jobs:
 
       - name: Prepare deploy directory
         run: |
-          mkdir -p deploy/shims deploy/node_modules
+          mkdir -p deploy/shims deploy/vendor
 
           # demo.html as index page
           cp js/eryx-sandbox/demo.html deploy/index.html
@@ -591,7 +591,8 @@ jobs:
           cp -r js/eryx-sandbox/shims deploy/
 
           # preview2-shim (referenced by import map in demo.html)
-          cp -r js/eryx-sandbox/node_modules/@bytecodealliance deploy/node_modules/
+          # Uses vendor/ instead of node_modules/ because Cloudflare Pages ignores node_modules/
+          cp -r js/eryx-sandbox/node_modules/@bytecodealliance/preview2-shim deploy/vendor/preview2-shim
 
           # Headers file: tell browsers the .wasm files are brotli-encoded
           printf '/*.wasm\n  Content-Encoding: br\n' > deploy/_headers

--- a/js/eryx-sandbox/demo.html
+++ b/js/eryx-sandbox/demo.html
@@ -9,11 +9,11 @@
       "imports": {
         "@bsull/eryx": "./index.js",
         "@bsull/eryx/callbacks": "./shims/callbacks.js",
-        "@bytecodealliance/preview2-shim/cli": "./node_modules/@bytecodealliance/preview2-shim/lib/browser/cli.js",
-        "@bytecodealliance/preview2-shim/clocks": "./node_modules/@bytecodealliance/preview2-shim/lib/browser/clocks.js",
-        "@bytecodealliance/preview2-shim/filesystem": "./node_modules/@bytecodealliance/preview2-shim/lib/browser/filesystem.js",
-        "@bytecodealliance/preview2-shim/io": "./node_modules/@bytecodealliance/preview2-shim/lib/browser/io.js",
-        "@bytecodealliance/preview2-shim/random": "./node_modules/@bytecodealliance/preview2-shim/lib/browser/random.js"
+        "@bytecodealliance/preview2-shim/cli": "./vendor/preview2-shim/lib/browser/cli.js",
+        "@bytecodealliance/preview2-shim/clocks": "./vendor/preview2-shim/lib/browser/clocks.js",
+        "@bytecodealliance/preview2-shim/filesystem": "./vendor/preview2-shim/lib/browser/filesystem.js",
+        "@bytecodealliance/preview2-shim/io": "./vendor/preview2-shim/lib/browser/io.js",
+        "@bytecodealliance/preview2-shim/random": "./vendor/preview2-shim/lib/browser/random.js"
       }
     }
     </script>


### PR DESCRIPTION
## Summary
- Cloudflare Pages ignores `node_modules/` by default, so the `@bytecodealliance/preview2-shim` files were never deployed
- Requests for them returned `index.html` as SPA fallback (`text/html` MIME type), breaking the entire ES module import chain
- Moves preview2-shim to `vendor/preview2-shim/` and updates the import map in `demo.html` accordingly

## Test plan
- [ ] CI passes
- [ ] After merge, verify the CF Pages demo deployment loads correctly at the Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)