### PR TITLE
feat(demo): wire up packages tab with wheel upload and installation

### DIFF
--- a/js/demo/src/components/TabPackages.svelte
+++ b/js/demo/src/components/TabPackages.svelte
@@ -1,14 +1,68 @@
 <script lang="ts">
+  import { getSandboxState, runCode } from "../lib/sandbox.svelte";
+  import CodeEditor from "./CodeEditor.svelte";
+  import OutputBox from "./OutputBox.svelte";
+
+  type PackageStatus = "pending" | "installing" | "installed" | "error";
+
   interface Package {
     name: string;
     version: string;
     size: number;
+    file: File;
+    status: PackageStatus;
+    fileCount?: number;
+    error?: string;
   }
 
   let packages: Package[] = $state([]);
   let dragover = $state(false);
+  let sitePackagesConfigured = false;
+  let statusMessage: string | null = $state(null);
+  let statusType: "success" | "error" = $state("success");
 
-  function handleFiles(files: FileList) {
+  let state = $derived(getSandboxState());
+
+  let code = $state(`import example_pkg\nprint(example_pkg)`);
+  let output: string | null = $state(null);
+  let isError = $state(false);
+  let elapsed: number | null = $state(null);
+
+  async function run() {
+    const trimmed = code.trim();
+    if (!trimmed) return;
+    const result = await runCode(trimmed);
+    if (result.ok) {
+      output = result.result.stdout || result.result.stderr || "(no output)";
+      isError = false;
+    } else {
+      output = "Error: " + result.error;
+      isError = true;
+    }
+    elapsed = result.elapsed;
+  }
+
+  // Lazily loaded references to the filesystem shim and file tree
+  let _setFileData: ((data: any) => void) | null = null;
+  let fileTree: { dir: Record<string, any> } | null = null;
+
+  async function ensureFileTreeLoaded() {
+    if (fileTree) return;
+    const [shimMod, eryxMod] = await Promise.all([
+      import("@bytecodealliance/preview2-shim/filesystem"),
+      import("@bsull/eryx"),
+    ]);
+    _setFileData = shimMod._setFileData;
+    fileTree = (eryxMod as any)._fileTree;
+  }
+
+  function showStatus(msg: string, type: "success" | "error" = "success") {
+    statusMessage = msg;
+    statusType = type;
+    setTimeout(() => (statusMessage = null), 4000);
+  }
+
+  async function handleFiles(files: FileList) {
     for (const f of files) {
       if (!f.name.endsWith(".whl")) continue;
       const parts = f.name.replace(".whl", "").split("-");
@@ -16,9 +70,167 @@
         name: parts[0],
         version: parts[1] || "?",
         size: f.size,
+        file: f,
+        status: "pending",
       });
     }
-    packages = [...packages]; // trigger reactivity
+    packages = [...packages];
+
+    await ensureFileTreeLoaded();
+
+    // Install each pending package
+    for (const pkg of packages) {
+      if (pkg.status !== "pending") continue;
+      pkg.status = "installing";
+      packages = [...packages];
+      try {
+        await installWheel(pkg);
+        pkg.status = "installed";
+      } catch (e) {
+        pkg.status = "error";
+        pkg.error = (e as Error).message;
+        console.error(`Failed to install ${pkg.name}:`, e);
+      }
+      packages = [...packages];
+    }
+
+    // Configure sys.path if we have any installed packages
+    if (
+      !sitePackagesConfigured &&
+      packages.some((p) => p.status === "installed")
+    ) {
+      sitePackagesConfigured = true;
+      await runCode('import sys; sys.path.insert(0, "/site-packages")');
+    }
+
+    const installed = packages.filter((p) => p.status === "installed");
+    if (installed.length > 0) {
+      const latest = installed[installed.length - 1];
+      code = `import ${latest.name}\nprint(${latest.name})`;
+      showStatus(
+        `${installed.length} package${installed.length > 1 ? "s" : ""} installed`,
+      );
+    }
+  }
+
+  async function installWheel(pkg: Package) {
+    const arrayBuffer = await pkg.file.arrayBuffer();
+    const entries = await parseZip(new Uint8Array(arrayBuffer));
+    const sitePackages = fileTree!.dir["site-packages"];
+    let fileCount = 0;
+
+    for (const [path, data] of entries) {
+      // Skip .dist-info metadata directories and __pycache__
+      if (path.includes(".dist-info/") || path.includes("__pycache__/"))
+        continue;
+
+      const parts = path.split("/");
+      let current = sitePackages;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (!parts[i]) continue;
+        if (!current.dir) current.dir = {};
+        if (!current.dir[parts[i]]) current.dir[parts[i]] = { dir: {} };
+        current = current.dir[parts[i]];
+      }
+      const fileName = parts[parts.length - 1];
+      if (fileName) {
+        if (!current.dir) current.dir = {};
+        current.dir[fileName] = { source: data };
+        fileCount++;
+      }
+    }
+
+    pkg.fileCount = fileCount;
+    _setFileData!(fileTree);
+  }
+
+  /**
+   * Parse a ZIP file (wheel) and return [path, Uint8Array] entries.
+   */
+  async function parseZip(
+    data: Uint8Array,
+  ): Promise<[string, Uint8Array][]> {
+    const entries: [string, Uint8Array][] = [];
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+    // Find End of Central Directory record (scan backwards)
+    let eocdOffset = -1;
+    for (let i = data.length - 22; i >= 0; i--) {
+      if (view.getUint32(i, true) === 0x06054b50) {
+        eocdOffset = i;
+        break;
+      }
+    }
+    if (eocdOffset === -1) throw new Error("Not a valid ZIP file");
+
+    const cdOffset = view.getUint32(eocdOffset + 16, true);
+    const cdCount = view.getUint16(eocdOffset + 10, true);
+    let pos = cdOffset;
+
+    for (let i = 0; i < cdCount; i++) {
+      if (view.getUint32(pos, true) !== 0x02014b50) break;
+
+      const compressionMethod = view.getUint16(pos + 10, true);
+      const compressedSize = view.getUint32(pos + 20, true);
+      const uncompressedSize = view.getUint32(pos + 24, true);
+      const nameLen = view.getUint16(pos + 28, true);
+      const extraLen = view.getUint16(pos + 30, true);
+      const commentLen = view.getUint16(pos + 32, true);
+      const localHeaderOffset = view.getUint32(pos + 42, true);
+      const name = new TextDecoder().decode(
+        data.subarray(pos + 46, pos + 46 + nameLen),
+      );
+
+      pos += 46 + nameLen + extraLen + commentLen;
+
+      // Skip directories
+      if (name.endsWith("/")) continue;
+
+      // Read from local file header
+      const localNameLen = view.getUint16(localHeaderOffset + 26, true);
+      const localExtraLen = view.getUint16(localHeaderOffset + 28, true);
+      const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+
+      let fileData: Uint8Array;
+      if (compressionMethod === 0) {
+        // Stored (no compression)
+        fileData = data.slice(dataStart, dataStart + uncompressedSize);
+      } else if (compressionMethod === 8) {
+        // Deflate
+        const compressed = data.subarray(
+          dataStart,
+          dataStart + compressedSize,
+        );
+        const ds = new DecompressionStream("deflate-raw");
+        const writer = ds.writable.getWriter();
+        const reader = ds.readable.getReader();
+        writer.write(compressed);
+        writer.close();
+        const chunks: Uint8Array[] = [];
+        let totalLen = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+          totalLen += value.length;
+        }
+        fileData = new Uint8Array(totalLen);
+        let offset = 0;
+        for (const chunk of chunks) {
+          fileData.set(chunk, offset);
+          offset += chunk.length;
+        }
+      } else {
+        console.warn(
+          `Skipping ${name}: unsupported compression method ${compressionMethod}`,
+        );
+        continue;
+      }
+
+      entries.push([name, fileData]);
+    }
+
+    return entries;
   }
 
   function handleDrop(e: DragEvent) {
@@ -30,11 +242,16 @@
   let fileInput: HTMLInputElement;
 </script>
 
-<div class="info-banner">
-  <strong>Coming soon.</strong> Package installation is available in the Rust and
-  Python SDKs via <code>SandboxFactory</code>. Browser-side package loading is
-  planned.
-</div>
+<p class="hint">
+  Upload pure-Python wheels to make packages available for import. Files are
+  extracted into a virtual filesystem.
+</p>
+
+{#if statusMessage}
+  <div class="status" class:success={statusType === "success"} class:error={statusType === "error"}>
+    {statusMessage}
+  </div>
+{/if}
 
 <div
   class="upload-zone"
@@ -57,6 +274,7 @@
     type="file"
     accept=".whl"
     multiple
+    disabled={state.status !== "ready"}
     onchange={(e) => {
       const input = e.target as HTMLInputElement;
       if (input.files) handleFiles(input.files);
@@ -65,24 +283,68 @@
 </div>
 
 {#if packages.length > 0}
-  <h2 class="pkg-title">Uploaded Packages</h2>
+  <h2 class="pkg-title">Packages</h2>
   {#each packages as pkg}
     <div class="pkg-row">
       <strong>{pkg.name}</strong>
       {pkg.version}
       <span class="pkg-size">{(pkg.size / 1024).toFixed(1)} KB</span>
-      <span class="pkg-status">Installation API coming soon</span>
+      {#if pkg.status === "installed"}
+        <span class="pkg-status installed">Installed ({pkg.fileCount} files)</span>
+      {:else if pkg.status === "installing"}
+        <span class="pkg-status installing">Installing...</span>
+      {:else if pkg.status === "error"}
+        <span class="pkg-status error" title={pkg.error}>Error</span>
+      {:else}
+        <span class="pkg-status pending">Pending</span>
+      {/if}
     </div>
   {/each}
 {/if}
 
+<CodeEditor bind:value={code} onrun={run} placeholder="Try importing an installed package..." />
+
+<div class="btn-row">
+  <button
+    class="btn-primary"
+    disabled={state.status !== "ready"}
+    onclick={run}
+  >
+    Run (Ctrl+Enter)
+  </button>
+</div>
+
+{#if output != null}
+  <OutputBox {output} {isError} {elapsed} />
+{/if}
+
 <p class="pkg-hint">
-  Example packages that work with eryx: <strong>requests</strong>,
-  <strong>jinja2</strong>, <strong>pyyaml</strong>, <strong>httpx</strong>,
-  <strong>beautifulsoup4</strong> (pure Python wheels only).
+  Download wheels from <a href="https://pypi.org">PyPI</a> (look for
+  <code>py3-none-any.whl</code> files). Packages with native C extensions are
+  not supported in the browser.
 </p>
 
 <style>
+  .hint {
+    color: #666;
+    margin-top: 0;
+  }
+  .status {
+    padding: 12px;
+    margin-bottom: 16px;
+    border-radius: 6px;
+    font-size: 14px;
+  }
+  .status.success {
+    background: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+  }
+  .status.error {
+    background: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+  }
   .upload-zone {
     border: 2px dashed #ccc;
     border-radius: 8px;
@@ -125,12 +387,26 @@
     margin-left: 8px;
   }
   .pkg-status {
-    color: #737373;
     float: right;
+  }
+  .pkg-status.installed {
+    color: #28a745;
+  }
+  .pkg-status.installing {
+    color: #007bff;
+  }
+  .pkg-status.error {
+    color: #dc3545;
+  }
+  .pkg-status.pending {
+    color: #737373;
   }
   .pkg-hint {
     font-size: 13px;
     color: #737373;
     margin-top: 16px;
+  }
+  .pkg-hint a {
+    color: #007bff;
   }
 </style>

--- a/js/eryx-sandbox/index.d.ts
+++ b/js/eryx-sandbox/index.d.ts
@@ -89,3 +89,17 @@ export class Sandbox {
  * @throws If the Python code raises an unhandled exception
  */
 export function execute(code: string): Promise<ExecuteResult>;
+
+/**
+ * The virtual file tree backing the WASI filesystem.
+ *
+ * This is the same object passed to `_setFileData()` from the preview2-shim.
+ * It contains `python-stdlib` and `site-packages` directories. You can add
+ * files to `_fileTree.dir["site-packages"]` and then call `_setFileData(_fileTree)`
+ * to make them visible to the sandbox.
+ *
+ * @internal This is primarily for use by the demo app and advanced integrations.
+ */
+export const _fileTree: {
+  dir: Record<string, unknown>;
+};

--- a/js/eryx-sandbox/index.js
+++ b/js/eryx-sandbox/index.js
@@ -36,7 +36,13 @@ const stdlibTree = await loadStdlib();
 // files at the root of the preopen (mounted as /python-stdlib).
 // So we set the root fileData to contain the stdlib directory contents.
 const stdlibDir = stdlibTree.dir?.["python-stdlib"] || stdlibTree;
-_setFileData({ dir: { "python-stdlib": stdlibDir } });
+
+// Build the file tree with stdlib and an empty site-packages directory.
+// This tree is exported so consumers (e.g., the demo) can add packages to it.
+export const _fileTree = {
+  dir: { "python-stdlib": stdlibDir, "site-packages": { dir: {} } },
+};
+_setFileData(_fileTree);
 
 // Complete Python interpreter initialization.
 // The pre-initialized WASM has Python's core state baked in, but


### PR DESCRIPTION
## Summary

- Wires up the demo's Packages tab so uploaded `.whl` files are actually installed into the sandbox
- Parses wheels (ZIP format) in-browser using a minimal ZIP parser with `DecompressionStream` for deflate
- Extracts Python files into the WASI virtual filesystem under `/site-packages`
- Auto-configures `sys.path` to include `/site-packages` after first install
- Shows real-time installation status per package (pending/installing/installed/error)

## Changes

- `TabPackages.svelte`: Rewrote the Svelte component with full wheel installation flow — ZIP parsing, VFS extraction, status tracking, and `sys.path` configuration. Replaces the "coming soon" placeholder.
- `index.js`: Exports `_fileTree` (the virtual FS tree) so consumers can add packages to it. Pre-creates `site-packages` directory.
- `index.d.ts`: Added type declaration for `_fileTree`.

## Limitations

- Only pure-Python wheels (`py3-none-any`) work in the browser. Native extensions (`.so`) require the Rust-side linker which isn't available in JS.
- No dependency resolution — users must upload all dependencies manually.

## Test plan

- [x] No Rust code changed — `cargo check` not needed
- [ ] CI passes (JS tests should still pass since `_fileTree` export is additive)
- [ ] Manual testing: upload a pure-Python wheel (e.g., `six`, `toml`) and verify `import` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)