### PR TITLE
fix(ci): use portable CPU features for cwasm precompilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             crates/eryx-runtime/runtime.cwasm
             crates/eryx-runtime/prebuilt/
             crates/eryx-wasm-runtime/target/liberyx_runtime.so
-          key: wasm-runtime-${{ hashFiles('crates/eryx-wasm-runtime/src/**', 'crates/eryx-wasm-runtime/clock_stubs.c', 'crates/eryx-wasm-runtime/Cargo.toml', 'crates/eryx-runtime/build.rs', 'crates/eryx-runtime/wit/runtime.wit', 'crates/eryx-runtime/libs/*.zst', 'Cargo.lock') }}
+          key: wasm-runtime-v2-${{ hashFiles('crates/eryx-wasm-runtime/src/**', 'crates/eryx-wasm-runtime/clock_stubs.c', 'crates/eryx-wasm-runtime/Cargo.toml', 'crates/eryx-runtime/build.rs', 'crates/eryx-runtime/wit/runtime.wit', 'crates/eryx-runtime/libs/*.zst', 'Cargo.lock') }}
 
       - name: Touch cached artifacts
         if: steps.wasm-cache.outputs.cache-hit == 'true'
@@ -122,6 +122,9 @@ jobs:
           cargo run -p eryx --example precompile --features preinit --release
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          # Use x86-64-v2 for portable cwasm across runner types (Namespace has AVX-512,
+          # but downstream jobs on ubuntu-latest do not)
+          ERYX_CPU_FEATURES: "x86-64-v2"
 
       - name: Upload WASM artifacts (cache miss)
         if: steps.wasm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           path: |
             crates/eryx-runtime/runtime.wasm
-          key: wasm-runtime-${{ hashFiles('crates/eryx-wasm-runtime/src/**', 'crates/eryx-wasm-runtime/clock_stubs.c', 'crates/eryx-wasm-runtime/Cargo.toml', 'crates/eryx-runtime/build.rs', 'crates/eryx-runtime/wit/runtime.wit', 'crates/eryx-runtime/libs/*.zst', 'Cargo.lock') }}
+          key: wasm-runtime-v2-${{ hashFiles('crates/eryx-wasm-runtime/src/**', 'crates/eryx-wasm-runtime/clock_stubs.c', 'crates/eryx-wasm-runtime/Cargo.toml', 'crates/eryx-runtime/build.rs', 'crates/eryx-runtime/wit/runtime.wit', 'crates/eryx-runtime/libs/*.zst', 'Cargo.lock') }}
 
       - name: Touch cached WASM
         if: steps.wasm-cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
## Summary

Fixes CI failure on main where cwasm precompiled on Namespace runners (which have AVX-512) can't load on ubuntu-latest runners (which don't).

**Error:** `compilation setting "has_avx512bitalg" is enabled, but not available on the host`

## Changes

- Set `ERYX_CPU_FEATURES=x86-64-v2` on the Precompile step so cwasm is portable across runner types
- Bump cache key from `wasm-runtime-` to `wasm-runtime-v2-` to invalidate the cached AVX-512 cwasm

## Root cause

PR #84 moved downstream jobs to free `ubuntu-latest` runners but kept `build-eryx-runtime` on Namespace. The precompile step used native CPU features by default, producing a cwasm with AVX-512 instructions that ubuntu-latest can't execute.

This wasn't caught on the PR branch because the cache was populated by an earlier all-ubuntu-latest run (which used x86-64-v2). On main, the cache was empty so Namespace built a fresh cwasm with native AVX-512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)