### PR TITLE
fix(ci): use future timestamps to prevent WASM rebuild in deploy-demo

### DIFF
--- a/.github/actions/mark-wasm-current/action.yml
+++ b/.github/actions/mark-wasm-current/action.yml
@@ -7,12 +7,16 @@ runs:
     - name: Mark WASM as up-to-date
       shell: bash
       run: |
-        # Touch WASM artifacts to be newer than sources so mise skips rebuild
-        touch crates/eryx-runtime/runtime.wasm crates/eryx-runtime/runtime.cwasm
+        # Touch WASM artifacts with a future timestamp so mise reliably skips
+        # rebuild. A plain `touch` uses the current second which can collide
+        # with checkout timestamps, causing mise to consider sources as
+        # equal-or-newer and trigger a full wasm-build from source.
+        FUTURE=$(date -d "+5 minutes" +%Y%m%d%H%M.%S)
+        touch -t "$FUTURE" crates/eryx-runtime/runtime.wasm crates/eryx-runtime/runtime.cwasm
 
         # Touch prebuilt artifacts if they exist
         if [ -d crates/eryx-runtime/prebuilt ]; then
-          touch crates/eryx-runtime/prebuilt/*
+          touch -t "$FUTURE" crates/eryx-runtime/prebuilt/*
         fi
 
         # Check if prebuilt artifacts changed by comparing checksums


### PR DESCRIPTION
## Summary

- The deploy-demo CI job was failing because `mise run build` triggered a full `wasm-build` from source, despite the WASM artifact already being downloaded from the `build-eryx-runtime` job
- Root cause: `mark-wasm-current` used plain `touch` which sets the current second—this can collide with `actions/checkout` timestamps, so mise sees sources as equal-or-newer and triggers a rebuild
- Fix: touch artifacts with a +5 minute future timestamp so mise's source/output comparison reliably skips `wasm-build`

Introduced in #90 which switched deploy-demo from inline commands to `mise run build`.

## Test plan

- [ ] CI `Deploy Demo` job passes (no longer tries to build WASM from source)
- [ ] Other jobs using `mark-wasm-current` (lint, test, doc, etc.) continue working


🤖 Generated with [Claude Code](https://claude.com/claude-code)