### PR TITLE
fix(demo): add Cache-Control: no-transform to prevent CF re-compression

### DIFF
--- a/js/demo/test/build.test.ts
+++ b/js/demo/test/build.test.ts
@@ -21,18 +21,17 @@ describe("demo build", () => {
     expect(assets.some((f: string) => f.endsWith(".wasm"))).toBe(true);
     expect(assets.some((f: string) => f.includes(".gz"))).toBe(true);
 
-    // Verify WASM files are brotli-compressed (brotli magic: 0xce 0xb2 0xcf 0x81)
-    // Brotli doesn't have a fixed magic number, but compressed output won't
-    // start with the WASM magic (\0asm = 0x00 0x61 0x73 0x6d)
+    // Verify WASM files are brotli-compressed (won't start with WASM magic \0asm)
     const wasmFiles = assets.filter((f: string) => f.endsWith(".wasm"));
     for (const wf of wasmFiles) {
       const bytes = readFileSync(resolve(distDir, "assets", wf));
       expect(bytes[0]).not.toBe(0x00); // not raw WASM
     }
 
-    // Verify _headers file exists for Cloudflare Pages
+    // Verify _headers file sets Content-Encoding and no-transform
     const headers = readFileSync(resolve(distDir, "_headers"), "utf-8");
     expect(headers).toContain("Content-Encoding: br");
+    expect(headers).toContain("no-transform");
   });
 
   it("serves .tar.gz without Content-Encoding in preview mode", async () => {

--- a/js/demo/vite.config.ts
+++ b/js/demo/vite.config.ts
@@ -55,9 +55,12 @@ export default defineConfig({
         server.middlewares.use(serveGzipRaw);
       },
     },
-    // Brotli-compress .wasm files in dist/ and write a Cloudflare _headers
-    // file so they're served with Content-Encoding: br. The largest WASM core
-    // is ~27MB uncompressed, which exceeds CF Pages' 25MB file limit.
+    // Brotli-compress .wasm files and write a Cloudflare Pages _headers file.
+    // We compress ourselves because some WASM cores exceed CF Pages' 25 MiB
+    // file limit. The _headers file sets Content-Encoding: br (so browsers
+    // decompress before WebAssembly.compileStreaming()) and Cache-Control:
+    // no-transform (so CF's CDN proxy on custom domains doesn't decompress
+    // and re-compress on the fly, which causes multi-minute load times).
     {
       name: "brotli-wasm",
       closeBundle() {
@@ -67,15 +70,16 @@ export default defineConfig({
           if (!file.endsWith(".wasm")) continue;
           const filePath = resolve(assetsDir, file);
           const raw = readFileSync(filePath);
-          const compressed = brotliCompressSync(raw, {
-            params: { [constants.BROTLI_PARAM_QUALITY]: 9 },
-          });
-          writeFileSync(filePath, compressed);
+          writeFileSync(
+            filePath,
+            brotliCompressSync(raw, {
+              params: { [constants.BROTLI_PARAM_QUALITY]: 9 },
+            }),
+          );
         }
-        // Cloudflare Pages _headers file
         writeFileSync(
           resolve(__dirname, "dist/_headers"),
-          "/assets/*.wasm\n  Content-Encoding: br\n",
+          `/assets/*.wasm\n  Content-Encoding: br\n  Cache-Control: public, no-transform\n`,
         );
       },
       // In preview mode, serve brotli-compressed .wasm with Content-Encoding: br
@@ -111,9 +115,8 @@ export default defineConfig({
     // We require JSPI (Chrome 133+), so modern targets are fine.
     // esnext is needed for top-level await in the eryx package.
     target: "esnext",
-    // Disable gzip size reporting - we serve with brotli via Cloudflare,
-    // so the gzip numbers are misleading (and slow down the build for
-    // large WASM files).
+    // Disable compressed size reporting - slow for large WASM files and
+    // misleading since we pre-compress with Brotli.
     reportCompressedSize: false,
   },
   optimizeDeps: {


### PR DESCRIPTION
WASM files are pre-compressed with Brotli (some exceed CF Pages' 25 MiB
file limit). On the production custom domain (demo.eryx.run), CF's CDN
proxy was decompressing and re-compressing these files on the fly on
every cache miss, causing multi-minute load times (KB/s speeds).

Adding `Cache-Control: no-transform` to the _headers file instructs
CF's proxy to serve the pre-compressed bytes as-is without modification.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>