### PR TITLE
chore(ci): skip jobs when relevant paths haven't changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,56 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # Detect which paths changed to skip unnecessary jobs.
+  # Each downstream job has an explicit 'github.event_name == push' override
+  # so that all jobs always run on pushes to main.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      python: ${{ steps.filter.outputs.python }}
+      book: ${{ steps.filter.outputs.book }}
+      examples: ${{ steps.filter.outputs.examples }}
+      js: ${{ steps.filter.outputs.js }}
+      demo: ${{ steps.filter.outputs.demo }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'crates/eryx-core/**'
+              - 'crates/eryx/**'
+              - 'crates/eryx-wasm-runtime/**'
+              - 'crates/eryx-runtime/**'
+              - 'crates/eryx-precompile/**'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/**'
+            python:
+              - 'crates/eryx-python/**'
+            book:
+              - 'book/**'
+            examples:
+              - 'examples/**'
+            js:
+              - 'js/**'
+            demo:
+              - 'demo/**'
+
   # Fast check for dependency drift - runs in parallel with build
   unify-check:
     name: Dependency Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -27,10 +73,20 @@ jobs:
       - name: Check dependency unification
         run: cargo rail unify --check
 
-  # Build eryx-wasm-runtime and precompile it - other jobs depend on this
+  # Build eryx-wasm-runtime and precompile it - other jobs depend on this.
+  # Runs when core paths change, or when any downstream job needs WASM artifacts.
   build-eryx-runtime:
     name: Build eryx-runtime
     runs-on: namespace-profile-eryx-heavy-linux-amd64
+    needs: changes
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
+      || needs.changes.outputs.python == 'true'
+      || needs.changes.outputs.book == 'true'
+      || needs.changes.outputs.examples == 'true'
+      || needs.changes.outputs.js == 'true'
+      || needs.changes.outputs.demo == 'true'
     steps:
       - uses: namespacelabs/nscloud-checkout-action@v8
 
@@ -141,7 +197,10 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -168,7 +227,10 @@ jobs:
   test:
     name: Test
     runs-on: namespace-profile-eryx-heavy-linux-amd64
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
     steps:
       - uses: namespacelabs/nscloud-checkout-action@v8
 
@@ -222,6 +284,10 @@ jobs:
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -243,7 +309,10 @@ jobs:
   doc:
     name: Documentation
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -270,7 +339,10 @@ jobs:
   check-features:
     name: Check Feature Combinations
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -305,7 +377,11 @@ jobs:
   examples:
     name: Examples
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
+      || needs.changes.outputs.examples == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -351,7 +427,11 @@ jobs:
   python-bindings:
     name: Python Bindings
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
+      || needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -405,7 +485,12 @@ jobs:
   book-tests:
     name: Book Tests
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
+      || needs.changes.outputs.book == 'true'
+      || needs.changes.outputs.python == 'true'
     steps:
       - name: Free disk space
         run: |
@@ -537,8 +622,13 @@ jobs:
   deploy-demo:
     name: Deploy Demo
     runs-on: ubuntu-latest
-    needs: build-eryx-runtime
-    if: github.event.pull_request.head.repo.fork != true
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event.pull_request.head.repo.fork != true
+      && (github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
+      || needs.changes.outputs.js == 'true'
+      || needs.changes.outputs.demo == 'true')
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    paths:
+      - 'crates/eryx-core/**'
+      - 'crates/eryx/**'
+      - 'crates/eryx-wasm-runtime/**'
+      - 'crates/eryx-runtime/**'
+      - 'js/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - '.github/workflows/js.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Adds `dorny/paths-filter@v3` to detect which directory groups changed in PRs
- Conditionally skips CI jobs whose inputs haven't been modified
- All jobs still run on pushes to main as a safety net
- JS workflow uses simpler workflow-level `paths` filter on `pull_request`

## Path groups

| Group | Paths | Jobs triggered |
|-------|-------|----------------|
| `core` | `crates/eryx-core/**`, `crates/eryx/**`, `crates/eryx-wasm-runtime/**`, `crates/eryx-runtime/**`, `crates/eryx-precompile/**`, `Cargo.lock`, `Cargo.toml`, `.github/workflows/ci.yml`, `.github/actions/**` | All jobs |
| `python` | `crates/eryx-python/**` | python-bindings, book-tests |
| `book` | `book/**` | book-tests, deploy-book |
| `examples` | `examples/**` | examples |
| `js` | `js/**` | deploy-demo, JS workflow |
| `demo` | `demo/**` | deploy-demo |

## Expected savings on PRs

- Book-only changes: skip test, lint, examples, python-bindings, check-features, doc, deploy-demo (~30+ min saved)
- Python binding changes: skip test, lint, examples, check-features, doc, deploy-demo (~25+ min saved)  
- Example changes: skip test, lint, python-bindings, book-tests, check-features, doc, deploy-demo (~30+ min saved)
- JS/demo changes: skip test, lint, examples, python-bindings, book-tests, check-features, doc (~35+ min saved)

## Test plan

- [x] YAML validates cleanly
- [ ] This PR itself only changes `.github/workflows/` — verify that `core` filter triggers all jobs (since CI config is in core paths)
- [ ] Create a test PR that only touches `book/` and verify only book-tests + build-eryx-runtime run
- [ ] Verify push to main still runs all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)