### PR TITLE
build(deps): bump wasmtime from 41 to 43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
         with:
           mise_toml: |
             [tools]
-            rust = "1.90"
+            rust = "1.91"
 
       - name: Check MSRV
         # Exclude crates that require WASM artifacts or WASI SDK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
@@ -554,46 +554,48 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a04121a197fde2fe896f8e7cac9812fc41ed6ee9c63e1906090f9f497845f6"
+checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09e699a94f477303820fb2167024f091543d6240783a2d3b01a3f21c42bc744"
+checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07732c662a9755529e332d86f8c5842171f6e98ba4d5976a178043dad838654"
+checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18391da761cf362a06def7a7cf11474d79e55801dd34c2e9ba105b33dc0aef88"
+checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a09b3042c69810d255aef59ddc3b3e4c0644d1d90ecfd6e3837798cc88a3c"
+checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -605,7 +607,8 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+ "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
@@ -613,14 +616,14 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75817926ec812241889208d1b190cadb7fedded4592a4bb01b8524babb9e4849"
+checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -631,35 +634,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859158f87a59476476eda3884d883c32e08a143cf3d315095533b362a3250a63"
+checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b65a9aec442d715cbf54d14548b8f395476c09cef7abe03e104a378291ab88"
+checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334c99a7e86060c24028732efd23bac84585770dcb752329c69f135d64f2fc1"
+checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ac6c095aa5b3e845d7ca3461e67e2b65249eb5401477a5ff9100369b745111"
+checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -669,15 +673,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3d992870ed4f0f2e82e2175275cb3a123a46e9660c6558c46417b822c91fa"
+checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
 
 [[package]]
 name = "cranelift-native"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee32e36beaf80f309edb535274cfe0349e1c5cf5799ba2d9f42e828285c6b52e"
+checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -686,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.128.4"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903adeaf4938e60209a97b53a2e4326cd2d356aab9764a1934630204bae381c9"
+checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
 
 [[package]]
 name = "crc"
@@ -1175,12 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,11 +1425,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -1489,6 +1488,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2201,12 +2202,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "memchr",
 ]
@@ -2586,21 +2587,21 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9812652c1feb63cf39f8780cecac154a32b22b3665806c733cd4072547233a4"
+checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
 dependencies = [
  "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56000349b6896e3d44286eb9c330891237f40b27fd43c1ccc84547d0b463cb40"
+checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2891,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -4123,9 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.243.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af801b6f36459023eaec63fdbaedad2fd5a4ab7dc74ecc110a8b5d375c5775e4"
+checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
 dependencies = [
  "anyhow",
  "heck",
@@ -4137,8 +4138,8 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wat",
 ]
 
@@ -4160,6 +4161,26 @@ checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -4212,24 +4233,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.243.0"
+name = "wasmparser"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a83182bf04af87571b4c642300479501684f26bab5597f68f68cded5b098fd"
+checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
 dependencies = [
  "addr2line",
- "anyhow",
  "async-trait",
  "bitflags",
  "bumpalo",
@@ -4239,8 +4283,6 @@ dependencies = [
  "futures",
  "fxprof-processed-profile",
  "gimli",
- "hashbrown 0.15.5",
- "indexmap",
  "ittapi",
  "libc",
  "log",
@@ -4260,18 +4302,17 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
@@ -4281,15 +4322,17 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb201c41aa23a3642365cfb2e4a183573d85127a3c9d528f56b9997c984541ab"
+checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "object",
@@ -4298,19 +4341,21 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmprinter",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5b3069d1a67ba5969d0eb1ccd7e141367d4e713f4649aa90356c98e8f19bea"
+checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
 dependencies = [
  "base64",
  "directories-next",
@@ -4328,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c924400db7b6ca996fef1b23beb0f41d5c809836b1ec60fc25b4057e2d25d9b"
+checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4338,20 +4383,32 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.243.0",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f65daf4bf3d74ca2fbbe20af0589c42e2b398a073486451425d94fd4afef4"
+checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "43.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "libm",
+ "serde",
+]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633e889cdae76829738db0114ab3b02fce51ea4a1cd9675a67a65fce92e8b418"
+checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4367,18 +4424,18 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb126adc5d0c72695cfb77260b357f1b81705a0f8fa30b3944e7c2219c17341"
+checksum = "20c8b2c9704eb1f33ead025ec16038277ccb63d0a14c31e99d5b765d7c36da55"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4391,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e66ff7f90a8002187691ff6237ffd09f954a0ebb9de8b2ff7f5c62632134120"
+checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
 dependencies = [
  "cc",
  "object",
@@ -4403,36 +4460,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b96df23179ae16d54fb3a420f84ffe4383ec9dd06fad3e5bc782f85f66e8e08"
+checksum = "3606662c156962d096be3127b8b8ae8ee2f8be3f896dad29259ff01ddb64abfd"
 dependencies = [
- "anyhow",
  "cfg-if",
  "libc",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-internal-math"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d1380926682b44c383e9a67f47e7a95e60c6d3fa8c072294dab2c7de6168a0"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "41.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b63cbea1c0192c7feb7c0dfb35f47166988a3742f29f46b585ef57246c65764"
-
-[[package]]
 name = "wasmtime-internal-unwinder"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c392c7e5fb891a7416e3c34cfbd148849271e8c58744fda875dde4bec4d6a"
+checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4443,9 +4485,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f8b9796a3f0451a7b702508b303d654de640271ac80287176de222f187a237"
+checksum = "d8b0a5dab02a8fb527f547855ecc0e05f9fdc3d5bd57b8b080349408f9a6cece"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4454,16 +4496,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0063e61f1d0b2c20e9cfc58361a6513d074a23c80b417aac3033724f51648a0"
+checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -4471,24 +4513,23 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587699ca7cae16b4a234ffcc834f37e75675933d533809919b52975f5609e2ef"
+checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.243.0",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "41.0.3"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a1bdb4948463ed22559a640e687fed0df50b66353144aa6a9496c041ecd927"
+checksum = "ed3e3ddcfad69e9eb025bd19bff70dad45bafe1d6eacd134c0ffdfc4c161d045"
 dependencies = [
- "anyhow",
  "async-trait",
  "bitflags",
  "bytes",
@@ -4515,28 +4556,27 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "41.0.3"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7873d8b990d3cf1105ef491abf2b3cf1e19ff6722d24d5ca662026ea082cdff"
+checksum = "3ca5dd3b9f04a851c422d05f333366722742da46bff9369ae0191f32cf83565a"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
+ "tracing",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasmtime-wizer"
-version = "41.0.3"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706314d2b968289707a7752a56d6e8b58b56a69e8721bcf157886cbe1f15577f"
+checksum = "f95b9da7eeae2785f6e64901b9aaa475dfb964d1e6b144b507364901e707f00f"
 dependencies = [
- "anyhow",
  "log",
  "rayon",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmtime",
 ]
 
@@ -4551,24 +4591,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "244.0.0"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7b9f9e23311275920e3d6b56d64137c160cf8af4f84a7283b36cfecbf4acb"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.244.0",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.244.0"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf35b87ed352f9ab6cd0732abde5a67dd6153dfd02c493e61459218b19456fa"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
- "wast 244.0.0",
+ "wast 246.0.2",
 ]
 
 [[package]]
@@ -4611,37 +4651,37 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "41.0.3"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f05d2a9932ca235984248dc98471ae83d1985e095682d049af4c296f54f0fb4"
+checksum = "cc1b1135efc8e5a008971897bea8d41ca56d8d501d4efb807842ae0a1c78f639"
 dependencies = [
- "anyhow",
  "bitflags",
  "thiserror 2.0.18",
  "tracing",
  "wasmtime",
+ "wasmtime-environ",
  "wiggle-macro",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "41.0.3"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f773d51c1696bd7d028aa35c884d9fc58f48d79a1176dfbad6c908de314235"
+checksum = "a7bc2b0d50ec8773b44fbfe1da6cb5cc44a92deaf8483233dcf0831e6db33172"
 dependencies = [
- "anyhow",
  "heck",
  "proc-macro2",
  "quote",
  "syn",
+ "wasmtime-environ",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "41.0.3"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e976fe0cecd60041f66b15ad45ebc997952af13da9bf9d90261c7b025057edc"
+checksum = "2d6c7d44ea552e1fbfdcd7a2cd83f5c2d1e803d5b1a11e3462c06888b77f455f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4682,11 +4722,10 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "41.0.4"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55de3ac5b8bd71e5f6c87a9e511dd3ceb194bdb58183c6a7bf21cd8c0e46fbc"
+checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
 dependencies = [
- "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
  "gimli",
@@ -4694,10 +4733,10 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -5130,6 +5169,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,10 @@ wasm-encoder = "0.243"
 wasmparser = "0.243"
 
 # WebAssembly runtime (v40+ required for async component model)
-wasmtime = { version = "41", features = ["component-model", "async"] }
-wasmtime-wasi = "41"
-wasmtime-wizer = { version = "41", features = ["component-model", "wasmtime"] }
+wasmtime = { version = "43", features = ["component-model", "async"] }
+wasmtime-wasi = "43"
+wasmtime-wasi-io = "43"
+wasmtime-wizer = { version = "43", features = ["component-model", "wasmtime"] }
 
 # WebAssembly component linking and WIT parsing
 wit-component = "0.243"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.4.8"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.91.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sd2k/eryx"
 authors = ["Ben Sully <ben.sully88@gmail.com>"]

--- a/crates/eryx-runtime/src/preinit.rs
+++ b/crates/eryx-runtime/src/preinit.rs
@@ -34,7 +34,7 @@
 //! ).await?;
 //! ```
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use std::collections::HashSet;
 use std::path::Path;
 use tempfile::TempDir;
@@ -110,13 +110,12 @@ pub async fn pre_initialize(
     let wizer = Wizer::new();
     let (cx, instrumented_wasm) = wizer
         .instrument_component(&original_component)
-        .context("Failed to instrument component")?;
+        .map_err(|e| e.context("Failed to instrument component"))?;
 
     // Phase 2: Instantiate and run the instrumented component.
     let mut config = Config::new();
     config.wasm_component_model(true);
     config.wasm_component_model_async(true);
-    config.async_support(true);
 
     let engine = Engine::new(&config)?;
     let component = Component::new(&engine, &instrumented_wasm)?;
@@ -219,7 +218,7 @@ pub async fn pre_initialize(
             },
         )
         .await
-        .context("Failed to pre-initialize component")?;
+        .map_err(|e| e.context("Failed to pre-initialize component"))?;
 
     // Phase 4: Restore _initialize exports stripped by wasmtime-wizer.
     //
@@ -571,7 +570,7 @@ fn add_network_stubs(linker: &mut Linker<PreInitCtx>) -> Result<()> {
     // Get or create the eryx:net/tcp interface
     let mut tcp_instance = linker
         .instance("eryx:net/tcp@0.1.0")
-        .context("Failed to get eryx:net/tcp instance")?;
+        .map_err(|e| e.context("Failed to get eryx:net/tcp instance"))?;
 
     // tcp.connect: func(host: string, port: u16) -> result<tcp-handle, tcp-error>
     tcp_instance.func_wrap_async(
@@ -627,7 +626,7 @@ fn add_network_stubs(linker: &mut Linker<PreInitCtx>) -> Result<()> {
     // Get or create the eryx:net/tls interface
     let mut tls_instance = linker
         .instance("eryx:net/tls@0.1.0")
-        .context("Failed to get eryx:net/tls instance")?;
+        .map_err(|e| e.context("Failed to get eryx:net/tls instance"))?;
 
     // tls.upgrade: func(tcp: tcp-handle, hostname: string) -> result<tls-handle, tls-error>
     tls_instance.func_wrap_async(
@@ -728,9 +727,7 @@ async fn call_execute_for_imports(
     execute_func
         .call_async(&mut *store, &args, &mut results)
         .await
-        .context("Failed to execute imports during pre-init")?;
-
-    execute_func.post_return_async(&mut *store).await?;
+        .map_err(|e| e.context("Failed to execute imports during pre-init"))?;
 
     // Check if the result was an error
     // result<string, string> is represented as Val::Result(Result<Option<Box<Val>>, Option<Box<Val>>>)
@@ -775,9 +772,7 @@ async fn call_finalize_preinit(store: &mut Store<PreInitCtx>, instance: &Instanc
     finalize_func
         .call_async(&mut *store, &args, &mut results)
         .await
-        .context("Failed to call finalize-preinit")?;
-
-    finalize_func.post_return_async(&mut *store).await?;
+        .map_err(|e| e.context("Failed to call finalize-preinit"))?;
 
     Ok(())
 }

--- a/crates/eryx-server/Dockerfile
+++ b/crates/eryx-server/Dockerfile
@@ -5,7 +5,7 @@
 ARG RUNTIME_SOURCE=default
 
 # ---------- Stage 1: Precompile WASM runtime (only when RUNTIME_SOURCE=default) ----------
-FROM rust:1.90-bookworm AS precompile
+FROM rust:1.91-bookworm AS precompile
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler \
@@ -64,7 +64,7 @@ COPY ${RUNTIME_CWASM} /build/crates/eryx-runtime/runtime.cwasm
 FROM runtime-${RUNTIME_SOURCE} AS runtime
 
 # ---------- Stage 2: Build the server binary ----------
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler \

--- a/crates/eryx-vfs/Cargo.toml
+++ b/crates/eryx-vfs/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 wasmtime.workspace = true
 wasmtime-wasi.workspace = true
-wasmtime-wasi-io = "41"
+wasmtime-wasi-io.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/eryx-vfs/src/bindings.rs
+++ b/crates/eryx-vfs/src/bindings.rs
@@ -43,7 +43,7 @@ impl From<wasmtime::component::ResourceTableError> for VfsFsError {
 
 impl VfsFsError {
     /// Convert to WASI error code.
-    pub fn downcast(self) -> anyhow::Result<generated::wasi::filesystem::types::ErrorCode> {
+    pub fn downcast(self) -> wasmtime::Result<generated::wasi::filesystem::types::ErrorCode> {
         Ok(crate::wasi_impl::vfs_error_to_error_code(&self.0))
     }
 }

--- a/crates/eryx-vfs/src/host.rs
+++ b/crates/eryx-vfs/src/host.rs
@@ -33,14 +33,14 @@ impl<S: VfsStorage + Clone + 'static> preopens::Host for VfsState<'_, S> {
 // ============================================================================
 
 impl<S: VfsStorage + Clone + 'static> types::Host for VfsState<'_, S> {
-    fn convert_error_code(&mut self, err: VfsFsError) -> anyhow::Result<types::ErrorCode> {
+    fn convert_error_code(&mut self, err: VfsFsError) -> wasmtime::Result<types::ErrorCode> {
         err.downcast()
     }
 
     fn filesystem_error_code(
         &mut self,
-        err: Resource<anyhow::Error>,
-    ) -> anyhow::Result<Option<types::ErrorCode>> {
+        err: Resource<wasmtime::Error>,
+    ) -> wasmtime::Result<Option<types::ErrorCode>> {
         let err = self.table.get(&err)?;
         if let Some(vfs_err) = err.downcast_ref::<crate::VfsError>() {
             return Ok(Some(vfs_error_to_error_code(vfs_err)));
@@ -353,7 +353,7 @@ impl<S: VfsStorage + Clone + 'static> types::HostDescriptor for VfsState<'_, S> 
         }
     }
 
-    fn drop(&mut self, fd: Resource<VfsDescriptor>) -> anyhow::Result<()> {
+    fn drop(&mut self, fd: Resource<VfsDescriptor>) -> wasmtime::Result<()> {
         self.table.delete(fd)?;
         Ok(())
     }
@@ -502,7 +502,7 @@ impl<S: VfsStorage + Clone + 'static> types::HostDescriptor for VfsState<'_, S> 
         &mut self,
         a: Resource<VfsDescriptor>,
         b: Resource<VfsDescriptor>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         let desc_a = self.table.get(&a)?;
         let desc_b = self.table.get(&b)?;
         Ok(desc_a.path == desc_b.path)
@@ -564,7 +564,7 @@ impl<S: VfsStorage + Clone + 'static> types::HostDirectoryEntryStream for VfsSta
         Ok(iterator.next())
     }
 
-    fn drop(&mut self, stream: Resource<VfsReaddirIterator>) -> anyhow::Result<()> {
+    fn drop(&mut self, stream: Resource<VfsReaddirIterator>) -> wasmtime::Result<()> {
         self.table.delete(stream)?;
         Ok(())
     }

--- a/crates/eryx-vfs/src/hybrid_bindings.rs
+++ b/crates/eryx-vfs/src/hybrid_bindings.rs
@@ -79,7 +79,7 @@ impl HybridReaddirIterator {
 
 impl HybridFsError {
     /// Convert to WASI error code.
-    pub fn downcast(self) -> anyhow::Result<types::ErrorCode> {
+    pub fn downcast(self) -> wasmtime::Result<types::ErrorCode> {
         Ok(vfs_error_to_error_code(&self.0))
     }
 }

--- a/crates/eryx-vfs/src/hybrid_host.rs
+++ b/crates/eryx-vfs/src/hybrid_host.rs
@@ -66,14 +66,14 @@ impl<S: VfsStorage + Clone + 'static> preopens::Host for HybridVfsState<'_, S> {
 // ============================================================================
 
 impl<S: VfsStorage + Clone + 'static> types::Host for HybridVfsState<'_, S> {
-    fn convert_error_code(&mut self, err: HybridFsError) -> anyhow::Result<types::ErrorCode> {
+    fn convert_error_code(&mut self, err: HybridFsError) -> wasmtime::Result<types::ErrorCode> {
         err.downcast()
     }
 
     fn filesystem_error_code(
         &mut self,
-        err: Resource<anyhow::Error>,
-    ) -> anyhow::Result<Option<types::ErrorCode>> {
+        err: Resource<wasmtime::Error>,
+    ) -> wasmtime::Result<Option<types::ErrorCode>> {
         let err = self.table.get(&err)?;
         if let Some(vfs_err) = err.downcast_ref::<crate::VfsError>() {
             return Ok(Some(crate::hybrid_bindings::vfs_error_to_error_code(
@@ -794,7 +794,7 @@ impl<S: VfsStorage + Clone + 'static> types::HostDescriptor for HybridVfsState<'
         }
     }
 
-    fn drop(&mut self, fd: Resource<HybridDescriptor>) -> anyhow::Result<()> {
+    fn drop(&mut self, fd: Resource<HybridDescriptor>) -> wasmtime::Result<()> {
         self.table.delete(fd)?;
         Ok(())
     }
@@ -1089,7 +1089,7 @@ impl<S: VfsStorage + Clone + 'static> types::HostDescriptor for HybridVfsState<'
         &mut self,
         a: Resource<HybridDescriptor>,
         b: Resource<HybridDescriptor>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         let desc_a = self.table.get(&a)?;
         let desc_b = self.table.get(&b)?;
         Ok(desc_a.path() == desc_b.path())
@@ -1191,7 +1191,7 @@ impl<S: VfsStorage + Clone + 'static> types::HostDirectoryEntryStream for Hybrid
         Ok(iterator.next())
     }
 
-    fn drop(&mut self, stream: Resource<HybridReaddirIterator>) -> anyhow::Result<()> {
+    fn drop(&mut self, stream: Resource<HybridReaddirIterator>) -> wasmtime::Result<()> {
         self.table.delete(stream)?;
         Ok(())
     }

--- a/crates/eryx-vfs/src/streams.rs
+++ b/crates/eryx-vfs/src/streams.rs
@@ -236,7 +236,9 @@ impl<S: VfsStorage + Clone + 'static> VfsInputStream<S> {
                     Ok(Bytes::from(data))
                 }
             }
-            Err(e) => Err(StreamError::LastOperationFailed(anyhow::anyhow!("{}", e))),
+            Err(e) => Err(StreamError::LastOperationFailed(wasmtime::Error::msg(
+                e.to_string(),
+            ))),
         }
     }
 }
@@ -365,7 +367,9 @@ impl<S: VfsStorage + Clone + 'static> VfsOutputStream<S> {
                 self.position = Some(write_position + data_len);
                 Ok(())
             }
-            Err(e) => Err(StreamError::LastOperationFailed(anyhow::anyhow!("{}", e))),
+            Err(e) => Err(StreamError::LastOperationFailed(wasmtime::Error::msg(
+                e.to_string(),
+            ))),
         }
     }
 }

--- a/crates/eryx-wasm-runtime/tests/runtime_test.rs
+++ b/crates/eryx-wasm-runtime/tests/runtime_test.rs
@@ -144,7 +144,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
 
     // Create engine with async and component model support
     let mut config = Config::new();
-    config.async_support(true);
     config.wasm_component_model(true);
     config.wasm_component_model_async(true);
 
@@ -382,7 +381,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("print(1+1)".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -399,7 +397,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("print('hello')\nprint('world')".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -419,7 +416,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("x = 42".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -436,7 +432,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("def broken(".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -456,7 +451,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("print(undefined_variable)".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -476,7 +470,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("my_var = 'persisted'".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
     match &result {
         Ok(_) => println!("  Assignment OK"),
         Err(e) => panic!("Assignment failed with: {e}"),
@@ -485,7 +478,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("print(my_var)".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -506,7 +498,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("import math; print(math.pi)".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -552,12 +543,10 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
             ("x = 42\ny = 'hello'\nz = [1, 2, 3]".to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
     assert!(result.is_ok(), "Setting variables should succeed");
 
     // Take a snapshot
     let (snapshot_result,) = snapshot_state.call_async(&mut store, ()).await?;
-    snapshot_state.post_return_async(&mut store).await?;
 
     let snapshot_data = match snapshot_result {
         Ok(data) => {
@@ -573,13 +562,11 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     // Test 9: Clear state
     println!("Test 9: Clear state...");
     clear_state.call_async(&mut store, ()).await?;
-    clear_state.post_return_async(&mut store).await?;
 
     // Verify variables are gone
     let (result,) = execute
         .call_async(&mut store, ("print(x)".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -599,7 +586,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (restore_result,) = restore_state
         .call_async(&mut store, (snapshot_data,))
         .await?;
-    restore_state.post_return_async(&mut store).await?;
 
     match &restore_result {
         Ok(()) => {
@@ -614,7 +600,6 @@ async fn test_instantiate_component() -> Result<(), Box<dyn std::error::Error>> 
     let (result,) = execute
         .call_async(&mut store, ("print(x, y, z)".to_string(),))
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -650,7 +635,6 @@ print(f"count: {len(cbs)}")
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -678,7 +662,6 @@ print(f"timestamp: {result.get('timestamp', 'missing')}")
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -710,7 +693,6 @@ print(f"callbacks: {names}")
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -737,7 +719,6 @@ print(f"add result: {result.get('result', 'missing')}")
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -765,7 +746,6 @@ print(f"url: {result.get('url', 'missing')}")
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -801,7 +781,6 @@ except RuntimeError as e:
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {
@@ -829,7 +808,6 @@ print("to stderr", file=sys.stderr)
             .to_string(),),
         )
         .await?;
-    execute.post_return_async(&mut store).await?;
 
     match &result {
         Ok(output) => {

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -328,7 +328,7 @@ impl ResourceLimiter for MemoryTracker {
         _current: usize,
         desired: usize,
         maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         // Track peak memory usage
         let desired_u64 = desired as u64;
         self.peak_memory_bytes
@@ -352,7 +352,7 @@ impl ResourceLimiter for MemoryTracker {
         _current: usize,
         desired: usize,
         maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         // Allow table growth up to the declared maximum
         if maximum.is_some_and(|max| desired > max) {
             return Ok(false);
@@ -366,8 +366,8 @@ impl ResourceLimiter for MemoryTracker {
 // Network functions are declared as regular sync `func` in WIT (not `async func`).
 // We use the `async` flag for network imports to generate `func_wrap_async` bindings.
 // This gives us fiber-based async: the host can await on async operations, but from
-// the guest's perspective the calls are blocking. This requires `Config::async_support`
-// but NOT `Config::wasm_component_model_async`.
+// the guest's perspective the calls are blocking. This requires
+// `Config::wasm_component_model_async`.
 wasmtime::component::bindgen!({
     path: "wit",
     imports: {
@@ -1551,7 +1551,6 @@ impl PythonExecutor {
         // TCP/TLS functions are sync `func` in WIT but use fiber-based async
         // on the host (via `async` bindgen flag) - they appear blocking to guest.
         config.wasm_component_model_async(true);
-        config.async_support(true);
 
         // Enable epoch-based interruption for execution timeouts.
         // This allows us to interrupt WASM execution even in tight loops
@@ -1608,7 +1607,6 @@ impl PythonExecutor {
         let mut config = Config::new();
         config.wasm_component_model(true);
         config.wasm_component_model_async(true);
-        config.async_support(true);
         config.epoch_interruption(true);
         config.consume_fuel(true);
         config.memory_init_cow(true);

--- a/mise.toml
+++ b/mise.toml
@@ -486,7 +486,7 @@ depends = ["build-eryx-runtime", "build"]
 
 [tasks.msrv]
 description = "Check compilation on minimum supported Rust version"
-run = "cargo +1.90 check --workspace"
+run = "cargo +1.91 check --workspace"
 
 [tasks.example-demo]
 description = "Run the demo example"


### PR DESCRIPTION
## Summary
- Bump `wasmtime`, `wasmtime-wasi`, `wasmtime-wasi-io`, and `wasmtime-wizer` from v41 to v43
- Migrate `anyhow::Error` → `wasmtime::Error` in trait implementations (ResourceLimiter, WASI host traits, stream drops)
- Remove deprecated `config.async_support()` and `post_return_async()` calls
- Move `wasmtime-wasi-io` into workspace dependencies

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)