### PR TITLE
feat(server): add OpenTelemetry trace context propagation

### DIFF
--- a/crates/eryx-server/proto/eryx/v1/eryx.proto
+++ b/crates/eryx-server/proto/eryx/v1/eryx.proto
@@ -191,6 +191,11 @@ message CallbackRequest {
 
   // JSON-encoded arguments object.
   string arguments_json = 3;
+
+  // W3C traceparent header for distributed trace propagation.
+  // Allows the client to link callback handling spans as children of the
+  // server-side callback span. Empty when tracing is not configured.
+  string trace_context = 4;
 }
 
 // Client responds with the result of a callback invocation.

--- a/crates/eryx-server/src/callbacks.rs
+++ b/crates/eryx-server/src/callbacks.rs
@@ -4,12 +4,14 @@
 //! that send callback requests over the gRPC response stream and await
 //! responses from the client via per-request oneshot channels.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
 use dashmap::DashMap;
 use eryx::{CallbackError, DynamicCallback};
 use tokio::sync::{mpsc, oneshot};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 use crate::proto::eryx::v1::{CallbackDeclaration, CallbackRequest, ServerMessage, server_message};
@@ -72,6 +74,17 @@ pub fn build_callbacks(
                         let (resp_tx, resp_rx) = oneshot::channel();
                         pending.insert(request_id.clone(), resp_tx);
 
+                        // Capture the current span's trace context so the Go
+                        // client can create child spans for callback handling.
+                        let trace_context = {
+                            let cx = tracing::Span::current().context();
+                            let mut fields = HashMap::new();
+                            opentelemetry::global::get_text_map_propagator(|propagator| {
+                                propagator.inject_context(&cx, &mut fields);
+                            });
+                            fields.remove("traceparent").unwrap_or_default()
+                        };
+
                         // Send the callback request to the Go client.
                         let msg = ServerMessage {
                             message: Some(server_message::Message::CallbackRequest(
@@ -79,6 +92,7 @@ pub fn build_callbacks(
                                     request_id: request_id.clone(),
                                     name: name.clone(),
                                     arguments_json,
+                                    trace_context,
                                 },
                             )),
                         };

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -619,9 +619,10 @@ async fn execute_with_session(
     let cb_map: Arc<HashMap<String, Arc<dyn Callback>>> = Arc::new(callbacks_ref.clone());
     let cb_secrets: Arc<HashMap<String, SecretConfig>> = Arc::new(params.secrets.clone());
     let resource_limits = params.resource_limits.clone();
-    let callback_handler = tokio::spawn(async move {
-        run_callback_handler(callback_rx, cb_map, resource_limits, cb_secrets).await
-    });
+    let callback_handler = tokio::spawn(
+        async move { run_callback_handler(callback_rx, cb_map, resource_limits, cb_secrets).await }
+            .instrument(tracing::Span::current()),
+    );
 
     // Compute preamble line count so trace events can be adjusted to user code lines.
     let preamble_lines = {

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -12,17 +12,40 @@ use eryx::{
     PythonStateSnapshot, ResourceLimits, SandboxPool, SecretConfig, SessionExecutor, TraceRequest,
     VfsConfig, generate_placeholder, scrub_placeholders,
 };
+use opentelemetry::propagation::Extractor;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
+use tonic::metadata::MetadataMap;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::callbacks::{self, CallbackResult, PendingCallbacks};
 use crate::proto::eryx::v1::{
     ClientMessage, ExecuteResult, ExecuteStats, FileKind, ServerMessage, SupportingFile,
     callback_response, client_message, server_message,
 };
+
+/// Adapts tonic's [`MetadataMap`] to OpenTelemetry's [`Extractor`] trait,
+/// allowing the propagator to read `traceparent`/`tracestate` from gRPC metadata.
+struct MetadataExtractor<'a>(&'a MetadataMap);
+
+impl Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0
+            .keys()
+            .filter_map(|k| match k {
+                tonic::metadata::KeyRef::Ascii(key) => Some(key.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+}
 
 /// The Eryx gRPC service.
 ///
@@ -48,6 +71,12 @@ impl crate::proto::eryx::v1::eryx_server::Eryx for EryxService {
         &self,
         request: Request<Streaming<ClientMessage>>,
     ) -> Result<Response<Self::ExecuteStream>, Status> {
+        // Extract W3C trace context from incoming gRPC metadata so that spans
+        // created here become children of the caller's trace.
+        let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&MetadataExtractor(request.metadata()))
+        });
+
         let mut inbound = request.into_inner();
 
         // 1. Read the first message — must be ExecuteRequest.
@@ -151,6 +180,9 @@ impl crate::proto::eryx::v1::eryx_server::Eryx for EryxService {
             networking = net_config.is_some(),
             secrets = secrets.len(),
         );
+        if let Err(e) = span.set_parent(parent_cx) {
+            tracing::debug!("failed to set parent trace context: {e}");
+        }
 
         // 2. Parse resource limits.
         let resource_limits = if let Some(limits) = execute_req.resource_limits {

--- a/crates/eryx-server/src/telemetry.rs
+++ b/crates/eryx-server/src/telemetry.rs
@@ -12,6 +12,7 @@ use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
     Resource,
+    propagation::TraceContextPropagator,
     trace::{Sampler, SdkTracerProvider},
 };
 use tracing_error::ErrorLayer;
@@ -30,6 +31,10 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 ///
 /// Returns an error if the OTLP exporter fails to build (e.g. invalid endpoint).
 pub fn setup_tracing() -> Result<Option<SdkTracerProvider>, Box<dyn std::error::Error>> {
+    // Register the W3C TraceContext propagator so incoming `traceparent` headers
+    // are extracted and outgoing requests propagate context.
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
     let (telemetry_layer, provider) =
         match std::env::var(opentelemetry_otlp::OTEL_EXPORTER_OTLP_ENDPOINT) {
             Ok(endpoint) => {


### PR DESCRIPTION
## Summary
- Register W3C TraceContext propagator so incoming `traceparent` headers are extracted and outgoing context is injected
- Extract parent trace context from gRPC metadata in the `execute` handler so eryx-server spans become children of the caller's trace
- Inject current span's trace context into `CallbackRequest` messages via a new `trace_context` proto field, enabling the caller to link callback handling as child spans


## Test plan
- [x] `cargo clippy -p eryx-server -- -D warnings` passes
- [x] `cargo test -p eryx-server --lib` passes (19/19)
- [x] Deploy both this and the companion PR, verify traces in Tempo show connected spans across assistant → eryx-server → callback round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)