### PR TITLE
fix(pool): use builder config instead of hardcoding embedded runtime

### DIFF
--- a/crates/eryx/src/pool.rs
+++ b/crates/eryx/src/pool.rs
@@ -284,7 +284,7 @@ impl SandboxPool {
     /// ).await?;
     /// ```
     pub async fn new(
-        _builder: SandboxBuilder<state::Has, state::Has>,
+        builder: SandboxBuilder<state::Has, state::Has>,
         config: PoolConfig,
     ) -> Result<Self, PoolError> {
         // Validate configuration
@@ -299,28 +299,13 @@ impl SandboxPool {
             ));
         }
 
-        // Create a builder function that can create sandboxes on demand.
-        // We build one sandbox first to validate the configuration, then
-        // create a closure that rebuilds sandboxes with the same settings.
-        //
-        // Since SandboxBuilder consumes self on build(), we need to store
-        // enough information to recreate sandboxes. The embedded() builder
-        // is stateless, so we can just call it again.
+        // Extract the reusable sandbox factory from the builder.
+        // SandboxBuilder consumes self on build(), so we convert it to a
+        // closure that can recreate sandboxes with the same base configuration
+        // (wasm source + stdlib). Per-request settings like callbacks, packages,
+        // and resource limits are not captured -- those are set by the caller.
         let builder_fn: Arc<dyn Fn() -> Result<Sandbox, Error> + Send + Sync> =
-            Arc::new(move || {
-                // For now, we only support the embedded builder pattern.
-                // This creates a fresh embedded sandbox each time.
-                #[cfg(feature = "embedded")]
-                {
-                    Sandbox::embedded().build()
-                }
-                #[cfg(not(feature = "embedded"))]
-                {
-                    Err(Error::Initialization(
-                        "Pool requires embedded feature".to_string(),
-                    ))
-                }
-            });
+            Arc::new(builder.into_factory());
 
         let pool = Arc::new(StdMutex::new(VecDeque::with_capacity(config.max_size)));
         let semaphore = Arc::new(Semaphore::new(config.max_size));

--- a/crates/eryx/src/sandbox.rs
+++ b/crates/eryx/src/sandbox.rs
@@ -1864,6 +1864,56 @@ impl<R, S> SandboxBuilder<R, S> {
 
 // Build only available when BOTH runtime AND stdlib are configured
 impl SandboxBuilder<state::Has, state::Has> {
+    /// Convert this builder into a reusable factory closure.
+    ///
+    /// The factory captures the wasm source and stdlib path so it can create
+    /// fresh sandboxes on demand. Per-request settings (callbacks, packages,
+    /// resource limits, etc.) are NOT captured -- each sandbox starts with
+    /// defaults for those.
+    ///
+    /// This is used by [`SandboxPool`](crate::SandboxPool) to recreate sandboxes
+    /// since `build()` consumes the builder.
+    pub(crate) fn into_factory(self) -> Box<dyn Fn() -> Result<Sandbox, Error> + Send + Sync> {
+        let wasm_source = self.wasm_source;
+        let stdlib_path = self.python_stdlib_path;
+
+        Box::new(move || {
+            // Reconstruct a builder using the public API based on the captured config.
+            let builder = match &wasm_source {
+                #[cfg(feature = "embedded")]
+                WasmSource::EmbeddedRuntime => Sandbox::embedded(),
+                #[cfg(any(feature = "embedded", feature = "preinit"))]
+                WasmSource::PrecompiledFile(path) => {
+                    let stdlib = stdlib_path.as_ref().ok_or_else(|| {
+                        Error::Initialization("stdlib path required for precompiled file".into())
+                    })?;
+                    // SAFETY: The original builder was already constructed with unsafe
+                    // by the caller, who vouched for the .cwasm file's trustworthiness.
+                    #[allow(unsafe_code)]
+                    unsafe {
+                        Sandbox::builder()
+                            .with_precompiled_file(path)
+                            .with_python_stdlib(stdlib)
+                    }
+                }
+                WasmSource::File(path) => {
+                    let stdlib = stdlib_path
+                        .as_ref()
+                        .ok_or_else(|| Error::Initialization("stdlib path required".into()))?;
+                    Sandbox::builder()
+                        .with_wasm_file(path)
+                        .with_python_stdlib(stdlib)
+                }
+                _ => {
+                    return Err(Error::Initialization(
+                        "unsupported wasm source for pool factory".into(),
+                    ));
+                }
+            };
+            builder.build()
+        })
+    }
+
     /// Build the sandbox.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

- `SandboxPool::new()` accepted a `SandboxBuilder` but **ignored it**, hardcoding `Sandbox::embedded()` for all sandbox creation (the `_builder` parameter was underscore-prefixed/unused)
- This meant `--runtime-cwasm` on eryx-server had no effect — the pool always used the embedded runtime
- Add `SandboxBuilder::into_factory()` which captures the wasm source and stdlib path into a reusable closure that the pool uses to recreate sandboxes

## Test plan

- [x] Built eryx-server with fix, ran in Docker with `ERYX_RUNTIME_CWASM` pointing to a numpy-enabled runtime.cwasm
- [x] Verified `import numpy` works via gRPC (previously got `ModuleNotFoundError`)
- [x] Ran all 5 existing integration tests — all pass
- [x] `cargo clippy --all-features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)