### PR TITLE
ci: cap Namespace cache volume at 2 GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          size: 2
 
       - uses: ./.github/actions/setup-rust
         if: steps.wasm-cache.outputs.cache-hit != 'true'
@@ -282,6 +283,7 @@ jobs:
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          size: 2
 
       - uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -62,6 +62,7 @@ jobs:
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          size: 2
 
       - uses: ./.github/actions/setup-rust
 


### PR DESCRIPTION
## Summary

Cap the `namespacelabs/nscloud-cache-action@v1` volume size at 2 GB across all three call sites. `nsc volume list` shows the rust cache volume currently uses only **116 MB of 50 GB provisioned** (a ~400x overprovision). Namespace bills on provisioned size, so this should shave the biggest line item off the monthly cache bill.

## Changes

- `.github/workflows/ci.yml` — `build-eryx-runtime` job (line 132)
- `.github/workflows/ci.yml` — `test` job (line 282)
- `.github/workflows/js-release.yml` — `build-and-test` job (line 62)

Each now sets `size: 2` under `with: cache: rust`. 2 GB still gives ~17x headroom over observed usage.

## Why this is safe

If the volume fills, Namespace evicts LRU entries rather than failing the build. The downside is a lower cache hit rate on cold builds — easy to recover by bumping the cap later if `build-eryx-runtime` step times regress.

## Manual follow-up after merge

The existing oversized volume keeps its 50 GB allocation until released. Release it so the next CI run provisions a fresh 2 GB one:

```
nsc volume release "github-namespace-profile-eryx-heavy-linux-amd64-eryx-org-eryx"
```

## Expected savings

Old: 50 GB × 30 days ≈ 15 cache-volume-units × \$0.48 ≈ \$7.20/month
New: 2 GB × 30 days ≈ 0.6 units × \$0.48 ≈ \$0.29/month

Separately, the unused `build-cluster-arm64` buildkit volume (0 MB used / 64 GB provisioned) has already been released via `nsc volume release`, which saves another ~\$9.80/month.

## Testing

- [x] YAML validates (`python3 -c "import yaml; ..."`)
- [ ] CI passes (this PR)
- [ ] Follow-up: verify `nsc volume list` after merge shows `size_mb: 2048`

🤖 Generated with [Claude Code](https://claude.com/claude-code)