### PR TITLE
ci: drop redundant nscloud-setup-buildx-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -808,9 +808,6 @@ jobs:
       - name: Prepare runtime.cwasm for Docker build context
         run: cp crates/eryx-runtime/runtime.cwasm crates/eryx-server/runtime.cwasm
 
-      - name: Set up Docker Buildx with Namespace cache
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
-
       - name: Log in to Docker Hub
         if: github.event_name == 'push'
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary

Remove `nscloud-setup-buildx-action@v0` from the Docker job. Namespace's own docs say this action is **redundant on Namespace-managed runners** — they come with buildx and Remote Builders configured out of the box. Our Docker job already runs on `namespace-profile-eryx-heavy-linux-amd64`, so the step is just wasted volume provisioning.

> "Workflows using Namespace-managed GitHub Runners can skip `nscloud-setup-buildx-action`."
> — [nscloud-setup-buildx-action README](https://github.com/namespacelabs/nscloud-setup-buildx-action#readme)

## Why this matters

`nsc volume list` shows the action creates two persistent buildkit volumes:

- `build-cluster-amd64;buildkitd.version=0.28.x` — 64 GB provisioned, 11.4 GB used
- `build-cluster-arm64;buildkitd.version=0.28.x` — 64 GB provisioned, **0 MB used** (this workflow only builds amd64)

Both volumes bill at ~\$9.80/month each (64 GB × 30 days × \$0.48 per 100 GB-day), for **~\$19.60/month total**.

## What happens after merge

`docker/build-push-action@v6` will use the runner's preconfigured buildx automatically. Build cache lives in Namespace's shared Remote Builder infrastructure (not a dedicated per-repo volume), so we may see more cache hits across builds rather than fewer.

Both buildkit volumes will be released automatically once nothing attaches to them, or can be released manually:

```
nsc volume release "build-cluster-amd64;buildkitd.version=0.28.x"
nsc volume release "build-cluster-arm64;buildkitd.version=0.28.x"
```

## Risk

If the runner's native builder behaves differently than the explicit cluster, Docker builds could be slower on the first cold build. Per the upstream docs this shouldn't happen. CI on this PR will surface any regression.

## Expected savings

Stacked on #200: total reduction on the Namespace bill is now **~\$36–37/month** (from ~\$55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)