### PR TITLE
build(deps): bump pyo3 from 0.27 to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,15 +1805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,15 +2064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix 1.1.3",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -2610,28 +2592,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -2640,18 +2620,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2659,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2671,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2684,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a8f29db331e28c332c63496cfcbb822aca3d7320bc08b655d7fd0c29c50ede"
+checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
 dependencies = [
  "pyo3",
  "serde",
@@ -3954,12 +3934,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ futures = "0.3"
 futures-concurrency = "7.6"
 futures-lite = "2.6"
 lending-stream = "1.0"
-pyo3 = { version = "^0.27.2", features = ["extension-module"] }
-pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
-pythonize = "0.27"
+pyo3 = { version = "^0.28", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+pythonize = "0.28"
 
 # JSON Schema
 schemars = "1.0.0-alpha.17"

--- a/crates/eryx-python/Cargo.toml
+++ b/crates/eryx-python/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 walkdir.workspace = true
 
 [build-dependencies]
-pyo3-build-config = "0.27"
+pyo3-build-config = "0.28"
 
 [lints]
 workspace = true

--- a/crates/eryx-python/src/net_config.rs
+++ b/crates/eryx-python/src/net_config.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 ///     # Allow localhost for local development
 ///     net = NetConfig.permissive()
 ///     sandbox = Sandbox(network=net)
-#[pyclass(module = "eryx")]
+#[pyclass(module = "eryx", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct NetConfig {
     /// Maximum concurrent connections.

--- a/crates/eryx-python/src/resource_limits.rs
+++ b/crates/eryx-python/src/resource_limits.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 ///         max_memory_bytes=100_000_000,  # 100MB memory limit
 ///     )
 ///     sandbox = Sandbox(resource_limits=limits)
-#[pyclass(module = "eryx")]
+#[pyclass(module = "eryx", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct ResourceLimits {
     /// Maximum execution time in milliseconds.

--- a/crates/eryx-python/src/result.rs
+++ b/crates/eryx-python/src/result.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 ///
 /// This class is returned by `Sandbox.execute()` and contains the output,
 /// timing information, and execution statistics.
-#[pyclass(frozen, module = "eryx")]
+#[pyclass(frozen, module = "eryx", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct ExecuteResult {
     /// Complete stdout output from the sandboxed code.

--- a/crates/eryx-python/src/vfs.rs
+++ b/crates/eryx-python/src/vfs.rs
@@ -26,7 +26,7 @@ use pyo3::prelude::*;
 ///     # Storage persists across executions within the session
 ///     result = session.execute('print(open("/data/test.txt").read())')
 ///     print(result.stdout)  # "hello"
-#[pyclass(module = "eryx")]
+#[pyclass(module = "eryx", from_py_object)]
 #[derive(Clone)]
 pub struct VfsStorage {
     /// The underlying type-erased storage.

--- a/crates/eryx-wasm-runtime/src/python.rs
+++ b/crates/eryx-wasm-runtime/src/python.rs
@@ -644,8 +644,9 @@ fn context_get_(py: Python<'_>) -> Option<Py<PyAny>> {
         // Convert raw pointer back to PyObject
         // The object was incref'd when stored, so we borrow it here
         let obj_ptr = ptr as *mut pyo3::ffi::PyObject;
-        // Create a Py<PyAny> from the raw pointer (steals reference)
-        Some(unsafe { Py::from_borrowed_ptr(py, obj_ptr) })
+        // Create a Bound<PyAny> from the raw pointer (borrows, incrementing refcount)
+        // then unbind to get Py<PyAny>
+        Some(unsafe { Bound::from_borrowed_ptr(py, obj_ptr) }.unbind())
     }
 }
 


### PR DESCRIPTION
## Summary
- Bumps pyo3, pyo3-async-runtimes, pythonize from 0.27 to 0.28
- Bumps pyo3-build-config from 0.27 to 0.28
- Fixes breaking changes:
  - Replaced deprecated `Py::from_borrowed_ptr` with `Bound::from_borrowed_ptr().unbind()`
  - Added `from_py_object` attribute to `#[pyclass]` types that derive `Clone` (new 0.28 requirement)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)