### PR TITLE
ci: remove Namespace runners to eliminate cache storage costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
   # Runs when core paths change, or when any downstream job needs WASM artifacts.
   build-eryx-runtime:
     name: Build eryx-runtime
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     needs: changes
     if: >-
       github.event_name == 'push'
@@ -93,7 +93,7 @@ jobs:
       || needs.changes.outputs.js == 'true'
       || needs.changes.outputs.demo == 'true'
     steps:
-      - uses: namespacelabs/nscloud-checkout-action@v8
+      - uses: actions/checkout@v4
 
       - name: Cache WASM runtime artifacts
         id: wasm-cache
@@ -129,10 +129,7 @@ jobs:
 
       - name: Configure Rust cache
         if: steps.wasm-cache.outputs.cache-hit != 'true'
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: rust
-          size: 2
+        uses: Swatinem/rust-cache@v2
 
       - uses: ./.github/actions/setup-rust
         if: steps.wasm-cache.outputs.cache-hit != 'true'
@@ -186,8 +183,7 @@ jobs:
           cargo run -p eryx --example precompile --features preinit --release
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
-          # Use x86-64-v2 for portable cwasm across runner types (Namespace has AVX-512,
-          # but downstream jobs on ubuntu-latest do not)
+          # Use x86-64-v2 for portable cwasm across runner types
           ERYX_CPU_FEATURES: "x86-64-v2"
 
       - name: Upload WASM artifacts (cache miss)
@@ -238,14 +234,14 @@ jobs:
 
   test:
     name: Test
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     needs: [changes, build-eryx-runtime]
     if: >-
       github.event_name == 'push'
       || needs.changes.outputs.core == 'true'
       || needs.changes.outputs.server == 'true'
     steps:
-      - uses: namespacelabs/nscloud-checkout-action@v8
+      - uses: actions/checkout@v4
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -280,10 +276,7 @@ jobs:
           EOF
 
       - name: Configure Rust cache
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: rust
-          size: 2
+        uses: Swatinem/rust-cache@v2
 
       - uses: ./.github/actions/setup-rust
 
@@ -787,7 +780,7 @@ jobs:
   # expensive WASM precompilation step inside Docker. Only pushes on main.
   docker:
     name: Docker
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     needs: [changes, build-eryx-runtime]
     if: >-
       github.event.pull_request.head.repo.fork != true
@@ -797,7 +790,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: namespacelabs/nscloud-checkout-action@v8
+      - uses: actions/checkout@v4
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     # Only run for the main eryx crate release (not eryx-macros, eryx-vfs, etc.)
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -41,7 +41,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
 
-      - uses: namespacelabs/nscloud-checkout-action@v8
+      - uses: actions/checkout@v4
 
       - name: Cache WASM runtime artifacts
         id: wasm-cache
@@ -59,10 +59,7 @@ jobs:
           touch crates/eryx-runtime/runtime-preinit.wasm
 
       - name: Configure Rust cache
-        uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: rust
-          size: 2
+        uses: Swatinem/rust-cache@v2
 
       - uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -29,7 +29,7 @@ jobs:
   # This produces platform-independent artifacts only
   build-runtime:
     name: Build Runtime
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     # Only run for the main eryx crate release (not eryx-macros, eryx-vfs, etc.)
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -81,7 +81,7 @@ jobs:
   # Build wheels for Linux x86_64 (native build with precompile)
   linux-x86_64:
     name: Linux (x86_64)
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     needs: build-runtime
     steps:
       - uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
   # Build wheels for Linux musllinux x86_64 (for Alpine Linux)
   musllinux-x86_64:
     name: Linux musllinux (x86_64)
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     needs: build-runtime
     steps:
       - uses: actions/checkout@v4
@@ -225,7 +225,7 @@ jobs:
   # Build wheels for Linux aarch64 (native ARM build with precompile)
   linux-aarch64:
     name: Linux (aarch64)
-    runs-on: namespace-profile-eryx-heavy-linux-arm64
+    runs-on: ubuntu-24.04-arm
     needs: build-runtime
     steps:
       - uses: actions/checkout@v4
@@ -298,7 +298,7 @@ jobs:
   # Build wheels for Linux musllinux aarch64 (for Alpine Linux on ARM)
   musllinux-aarch64:
     name: Linux musllinux (aarch64)
-    runs-on: namespace-profile-eryx-heavy-linux-arm64
+    runs-on: ubuntu-24.04-arm
     needs: build-runtime
     steps:
       - uses: actions/checkout@v4
@@ -369,7 +369,7 @@ jobs:
   # Build wheels for macOS ARM (native build with precompile)
   macos-aarch64:
     name: macOS (aarch64)
-    runs-on: namespace-profile-eryx-heavy-macos-arm64
+    runs-on: macos-15
     needs: build-runtime
     steps:
       - uses: actions/checkout@v4
@@ -414,7 +414,6 @@ jobs:
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
 
-      # Use uv to manage Python - more reliable than setup-python on namespace runners
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.12"
@@ -606,7 +605,7 @@ jobs:
   # Build source distribution
   sdist:
     name: Source Distribution
-    runs-on: namespace-profile-eryx-heavy-linux-amd64
+    runs-on: ubuntu-latest
     needs: build-runtime
     steps:
       - uses: actions/checkout@v4
@@ -636,7 +635,7 @@ jobs:
   # Publish to PyPI
   release:
     name: Publish to PyPI
-    runs-on: namespace-profile-eryx-light
+    runs-on: ubuntu-latest
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish)
     needs:
       [linux-x86_64, musllinux-x86_64, linux-aarch64, musllinux-aarch64, macos-aarch64, macos-x86_64, windows, sdist]


### PR DESCRIPTION
## Summary
- Replace all Namespace runner profiles with GitHub-hosted runners (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-15`)
- Replace `nscloud-cache-action` with `Swatinem/rust-cache@v2` (uses free GitHub Actions cache instead of Namespace's paid cache storage)
- Replace `nscloud-checkout-action` with `actions/checkout@v4`

## Risk
The `build-eryx-runtime` and `test` jobs previously ran on Namespace's heavy profile (likely 8-16 cores, more RAM/disk). On `ubuntu-latest` (4 cores, 16GB RAM, 14GB disk) the WASM build may:
- Run out of disk space (Rust + WASM build artifacts can be large)
- Run out of memory during `build-std` compilation
- Be significantly slower

If free runners aren't enough, we can switch those two jobs to GitHub's larger runners (e.g. `ubuntu-latest-8-cores`) which cost compute time but don't have separate cache storage fees.

## Test plan
- [ ] CI passes on this PR — especially `build-eryx-runtime`, `test`, and `docker` jobs
- [ ] If disk/memory issues arise, escalate to GitHub larger runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)