### PR TITLE
build: Target x86-64-v2 for precompiled Python wheel runtimes

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -122,6 +122,7 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          ERYX_CPU_FEATURES: "x86-64-v2"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -195,6 +196,7 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          ERYX_CPU_FEATURES: "x86-64-v2"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -487,6 +489,7 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          ERYX_CPU_FEATURES: "x86-64-v2"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -572,6 +575,7 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          ERYX_CPU_FEATURES: "x86-64-v2"
 
       - name: Mark cwasm as up-to-date
         shell: bash


### PR DESCRIPTION
Set ERYX_CPU_FEATURES=x86-64-v2 when precompiling runtime.cwasm for x86_64 Python release wheels.

(I did go with v2 instead of v3 for maximum compatibility and because it was the setting already used in `ci.yml`)

Fixes #221 