### PR TITLE
docs: lead with Python and add production/trust signals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.4.9"
 edition = "2024"
 rust-version = "1.92.0"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/sd2k/eryx"
+repository = "https://github.com/eryx-org/eryx"
 authors = ["Ben Sully <ben.sully88@gmail.com>"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 [![npm](https://img.shields.io/npm/v/@bsull/eryx.svg)](https://www.npmjs.com/package/@bsull/eryx)
 [![docs](https://img.shields.io/badge/docs-docs.eryx.run-blue)](https://docs.eryx.run)
 
+A WebAssembly sandbox for running **untrusted Python** safely — memory and CPU limits, no filesystem or network access by default, and async host callbacks for the access you _do_ want to allow.
+
+Embed it from **Python**, **JavaScript**, or **Rust**. Runs full **CPython 3.14** (not a limited subset), so the real standard library and most pure-Python packages just work. [Try the demo](https://demo.eryx.run) or [read the docs](https://docs.eryx.run).
+
+> **Used in production at [Grafana](https://grafana.com/).**
+
 > **eryx** (noun): A genus of sand boas (Erycinae) — non-venomous snakes that live _in_ sand.
 > Perfect for "Python running inside a sandbox."
-
-A Rust library that executes Python code in a WebAssembly sandbox with async callbacks. [Try the demo](https://demo.eryx.run) or [read the docs](https://docs.eryx.run).
 
 ## Features
 
@@ -31,6 +35,42 @@ A Rust library that executes Python code in a WebAssembly sandbox with async cal
 Eryx embeds **CPython 3.14** compiled to WebAssembly (WASI). The WASI-compiled CPython and standard library come from the [componentize-py](https://github.com/bytecodealliance/componentize-py) project by the Bytecode Alliance.
 
 ## Quick Start
+
+### Python
+
+```bash
+pip install pyeryx
+```
+
+> The package is published as `pyeryx` but imported as `eryx`.
+
+```python
+import eryx
+
+# Zero-config: ships with a pre-initialized CPython runtime, so this is fast (~1-5ms)
+sandbox = eryx.Sandbox()
+
+result = sandbox.execute('''
+print("Hello from the sandbox!")
+print(f"2 + 2 = {2 + 2}")
+''')
+
+print(result.stdout)
+```
+
+See the [PyPI package](https://pypi.org/project/pyeryx/) and [`crates/eryx-python`](crates/eryx-python/README.md) for the full Python API (sessions, callbacks, package loading, resource limits).
+
+### JavaScript
+
+```bash
+npm install @bsull/eryx
+```
+
+### Rust
+
+```bash
+cargo add eryx --features embedded
+```
 
 ```rust
 use eryx::Sandbox;

--- a/crates/eryx-python/README.md
+++ b/crates/eryx-python/README.md
@@ -1,6 +1,8 @@
 # PyEryx - Python Bindings for Eryx
 
-Python bindings for the [Eryx](https://github.com/sd2k/eryx) sandbox - execute Python code securely inside WebAssembly.
+Python bindings for the [Eryx](https://github.com/eryx-org/eryx) sandbox - execute untrusted Python code securely inside WebAssembly, from within a Python host.
+
+Eryx runs full **CPython 3.14** (not a limited subset), with memory and CPU limits, no filesystem or network access by default, and async host callbacks for the access you _do_ want to allow. **Used in production at [Grafana](https://grafana.com/).**
 
 ## Installation
 


### PR DESCRIPTION
## Why

[Simon Willison just shipped `micropython-wasm`](https://simonwillison.net/2026/Jun/6/micropython-in-a-sandbox/) to solve roughly the same problem eryx solves — safely running untrusted Python — despite having been keen on eryx previously. A likely contributor: eryx *presents* as a Rust library (Rust-first README, Rust-first Quick Start), so a Python developer landing on the repo bounces before discovering `pyeryx`. This PR fixes the positioning and a few trust signals, without touching any code.

## Changes

**Lead with Python**
- New intro positioning eryx as a sandbox for running **untrusted Python** safely (memory/CPU limits, no fs/network by default, async host callbacks), embeddable from **Python, JavaScript, or Rust**.
- Highlight full **CPython 3.14** (not a limited subset) as the key differentiator — the real stdlib and most pure-Python packages work.
- **Quick Start** now leads with `pip install pyeryx`, then JS (`@bsull/eryx`), then Rust. The `pyeryx`→`eryx` import quirk is surfaced inline.

**Trust signals**
- Note production use at **Grafana** in both the root and PyPI READMEs.
- Fix stale `sd2k/eryx` → `eryx-org/eryx` repository references (`Cargo.toml` `repository` field — inherited by `eryx-python` — and the PyPI README link).

## Scope

Docs and metadata only; no code changed, nothing to build or test. The `Cargo.toml` repository change propagates to crates.io on next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)