### PR TITLE
feat: callback suspension via fuel-poison halt

### DIFF
--- a/crates/eryx-python/src/error.rs
+++ b/crates/eryx-python/src/error.rs
@@ -64,6 +64,9 @@ pub fn eryx_error_to_py(err: eryx::Error) -> PyErr {
         ),
         eryx::Error::Snapshot(msg) => InitializationError::new_err(msg),
         eryx::Error::Cancelled => CancelledError::new_err("execution was cancelled"),
+        eryx::Error::Suspended(reason) => {
+            ExecutionError::new_err(format!("execution suspended: {reason}"))
+        }
         eryx::Error::FuelExhausted { consumed, limit } => ResourceLimitError::new_err(format!(
             "execution ran out of fuel after {consumed} instructions (limit: {limit})"
         )),

--- a/crates/eryx-server/proto/eryx/v1/eryx.proto
+++ b/crates/eryx-server/proto/eryx/v1/eryx.proto
@@ -408,6 +408,12 @@ enum FailureKind {
   FAILURE_KIND_SANDBOX_ERROR = 4;
   // Execution was cancelled before completing (e.g. the client disconnected).
   FAILURE_KIND_CANCELLED = 5;
+  // A callback requested suspension (CALLBACK_OUTCOME_SUSPEND). This is an
+  // expected control outcome, not a failure: `suspended` is true and the prefix
+  // journal / `suspended_callback` carry the state needed to resume. Branch on
+  // `suspended` first; this kind is a secondary signal for consumers that key
+  // solely on `failure_kind`.
+  FAILURE_KIND_SUSPENDED = 6;
 }
 
 // A trace event emitted during execution.

--- a/crates/eryx-server/proto/eryx/v1/eryx.proto
+++ b/crates/eryx-server/proto/eryx/v1/eryx.proto
@@ -242,9 +242,19 @@ message CallbackResponse {
     // JSON-encoded result on success.
     string json_result = 2;
 
-    // Error message on failure.
+    // Error message on failure, or the opaque suspend reason when
+    // `outcome == CALLBACK_OUTCOME_SUSPEND`.
     string error = 3;
   }
+
+  // How this callback resolved. Defaults to CALLBACK_OUTCOME_OK / ERROR based on
+  // the `result` oneof for backwards compatibility; set to
+  // CALLBACK_OUTCOME_SUSPEND to defer execution. When SUSPEND, execution stops
+  // cleanly: the callback is reported in ExecuteResult.suspended_callback, the
+  // guest is halted before any further code runs, and the journal of completed
+  // callbacks is returned so a later run can replay the prefix and resume. The
+  // suspend reason is carried in the `error` field of the `result` oneof.
+  CallbackOutcome outcome = 4;
 }
 
 // How a callback invocation resolved, for journaling and replay.
@@ -253,6 +263,19 @@ enum CallbackOutcome {
   CALLBACK_OUTCOME_OK = 0;
   // Permanent failure — the `value` is the error message.
   CALLBACK_OUTCOME_ERROR = 1;
+  // Suspend — defer execution. Only valid in CallbackResponse; never recorded in
+  // a journal entry (SUSPEND terminates execution before an entry is written).
+  CALLBACK_OUTCOME_SUSPEND = 2;
+}
+
+// Details of the callback that suspended execution.
+message SuspendedCallback {
+  // Name of the callback that suspended.
+  string name = 1;
+  // Canonicalized arguments JSON the callback was invoked with.
+  string args_json = 2;
+  // The opaque reason string the callback returned.
+  string reason = 3;
 }
 
 // A single recorded callback invocation in a replay journal.
@@ -356,6 +379,16 @@ message ExecuteResult {
   // Present only when the request opted into replay (sent a callback_journal).
   // Echo it back in the next ExecuteRequest to replay completed callbacks.
   CallbackJournal callback_journal = 10;
+
+  // True if a callback requested suspension (CALLBACK_OUTCOME_SUSPEND). When
+  // set, `success` is false and `error` describes the halted (fuel-poisoned)
+  // execution — that is expected, not a failure. Branch on `suspended` first;
+  // the suspension details are in `suspended_callback` and the prefix journal is
+  // in `callback_journal`, ready to resume.
+  bool suspended = 11;
+
+  // Details of the callback that suspended, when `suspended` is true.
+  SuspendedCallback suspended_callback = 12;
 }
 
 // Why an execution failed, when success is false.

--- a/crates/eryx-server/src/callbacks.rs
+++ b/crates/eryx-server/src/callbacks.rs
@@ -23,6 +23,10 @@ pub enum CallbackResult {
     Ok(String),
     /// Error message.
     Err(String),
+    /// The client asked to suspend execution ("retry later"). The string is the
+    /// opaque reason. Surfaced as [`CallbackError::Suspend`] so replay-aware
+    /// execution halts the guest and reports the suspension to the caller.
+    Suspend(String),
 }
 
 /// Map of pending callback requests, keyed by request ID.
@@ -163,6 +167,15 @@ pub fn build_callbacks(
                                     "callback response received"
                                 );
                                 Err(CallbackError::ExecutionFailed(err))
+                            }
+                            CallbackResult::Suspend(reason) => {
+                                tracing::info!(
+                                    callback_name = %name,
+                                    %request_id,
+                                    duration_ms,
+                                    "callback requested suspension"
+                                );
+                                Err(CallbackError::Suspend(reason))
                             }
                         }
                     })

--- a/crates/eryx-server/src/replay.rs
+++ b/crates/eryx-server/src/replay.rs
@@ -33,7 +33,9 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use eryx::{Callback, CallbackJournal, CallbackJournalEntry, ReplayCallback, ReplayState};
+use eryx::{
+    Callback, CallbackJournal, CallbackJournalEntry, ReplayCallback, ReplayState, SuspendedCallback,
+};
 use hmac::{Hmac, Mac};
 use prost::Message;
 use sha2::Sha256;
@@ -194,6 +196,16 @@ fn entry_to_proto(entry: &CallbackJournalEntry) -> pb::CallbackJournalEntry {
         args_json: entry.args_json.clone(),
         outcome: outcome as i32,
         value,
+    }
+}
+
+/// Convert an eryx [`SuspendedCallback`] into its proto form.
+#[must_use]
+pub fn suspended_to_proto(suspended: &SuspendedCallback) -> pb::SuspendedCallback {
+    pb::SuspendedCallback {
+        name: suspended.name.clone(),
+        args_json: suspended.args_json.clone(),
+        reason: suspended.reason.clone(),
     }
 }
 

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -24,7 +24,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::callbacks::{self, CallbackResult, PendingCallbacks};
 use crate::proto::eryx::v1::{
     CallbackOutcome, ClientMessage, ExecuteResult, ExecuteStats, FailureKind, FileKind,
-    ServerMessage, SupportingFile, callback_response, client_message, server_message,
+    ServerMessage, SupportingFile, SuspendedCallback, callback_response, client_message,
+    server_message,
 };
 
 /// Adapts tonic's [`MetadataMap`] to OpenTelemetry's [`Extractor`] trait,
@@ -889,10 +890,29 @@ async fn execute_with_session(
         }
         None => (None, 0, None),
     };
+    // A client can reply CALLBACK_OUTCOME_SUSPEND even without opting into replay.
+    // In that case there is no ReplayState to record the suspended callback's
+    // name/args, but the executor still returns Error::Suspended. Derive the
+    // suspension from the error so the outcome is reported as a suspension (with
+    // its reason) rather than mis-surfaced as an ordinary sandbox error. There is
+    // no prefix journal to resume from in this mode, but the signal is honest.
+    let suspended_callback = suspended_callback.or_else(|| match &exec_result {
+        Err(Error::Suspended(reason)) => Some(SuspendedCallback {
+            name: String::new(),
+            args_json: String::new(),
+            reason: reason.clone(),
+        }),
+        _ => None,
+    });
     let suspended = suspended_callback.is_some();
 
-    // Snapshot state after execution (only when persistence is requested).
-    let snapshot_bytes = if params.state.is_some() {
+    // Snapshot state after execution (only when persistence is requested, and not
+    // after a suspension: the guest's fuel is poisoned to 0 once a callback
+    // suspends, so invoking the snapshot_state export would trap immediately
+    // (OutOfFuel) and yield a misleading empty snapshot — which could clobber
+    // prior session state. Resume goes through journal replay, not the snapshot,
+    // so the snapshot is not needed here anyway.)
+    let snapshot_bytes = if params.state.is_some() && !suspended {
         let snapshot_start = Instant::now();
         match session.snapshot_state().await {
             Ok(snapshot) => {
@@ -1052,14 +1072,18 @@ async fn execute_with_session(
 /// Classify a library [`Error`] into the proto [`FailureKind`].
 ///
 /// [`Error::PythonException`] is a *script* failure — its traceback is surfaced
-/// in `stderr` — so it maps to [`FailureKind::ScriptException`]. Everything else
-/// is a sandbox-level failure whose message belongs in the `error` field.
+/// in `stderr` — so it maps to [`FailureKind::ScriptException`].
+/// [`Error::Suspended`] is an expected control outcome (a callback deferred), not
+/// a failure, so it maps to [`FailureKind::Suspended`]; callers should branch on
+/// the `suspended` flag first. Everything else is a sandbox-level failure whose
+/// message belongs in the `error` field.
 fn classify_failure(error: &Error) -> FailureKind {
     match error {
         Error::PythonException(_) => FailureKind::ScriptException,
         Error::Timeout(_) => FailureKind::Timeout,
         Error::FuelExhausted { .. } => FailureKind::FuelExhausted,
         Error::Cancelled => FailureKind::Cancelled,
+        Error::Suspended(_) => FailureKind::Suspended,
         _ => FailureKind::SandboxError,
     }
 }

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -23,8 +23,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::callbacks::{self, CallbackResult, PendingCallbacks};
 use crate::proto::eryx::v1::{
-    ClientMessage, ExecuteResult, ExecuteStats, FailureKind, FileKind, ServerMessage,
-    SupportingFile, callback_response, client_message, server_message,
+    CallbackOutcome, ClientMessage, ExecuteResult, ExecuteStats, FailureKind, FileKind,
+    ServerMessage, SupportingFile, callback_response, client_message, server_message,
 };
 
 /// Adapts tonic's [`MetadataMap`] to OpenTelemetry's [`Extractor`] trait,
@@ -335,18 +335,31 @@ impl crate::proto::eryx::v1::eryx_server::Eryx for EryxService {
                 while let Ok(Some(msg)) = inbound.message().await {
                     if let Some(client_message::Message::CallbackResponse(resp)) = msg.message {
                         let request_id = resp.request_id;
-                        let result = match resp.result {
-                            Some(callback_response::Result::JsonResult(json)) => {
-                                tracing::debug!(%request_id, "dispatching callback result (ok)");
-                                CallbackResult::Ok(json)
-                            }
-                            Some(callback_response::Result::Error(err)) => {
-                                tracing::debug!(%request_id, "dispatching callback result (error)");
-                                CallbackResult::Err(err)
-                            }
-                            None => {
-                                tracing::debug!(%request_id, "dispatching callback result (empty)");
-                                CallbackResult::Err("empty callback response".to_string())
+                        // A SUSPEND outcome takes precedence over the result oneof:
+                        // the reason is carried in the `error` field. This defers
+                        // execution (halts the guest) rather than surfacing an
+                        // ordinary value/exception.
+                        let result = if resp.outcome == CallbackOutcome::Suspend as i32 {
+                            let reason = match resp.result {
+                                Some(callback_response::Result::Error(err)) => err,
+                                _ => String::new(),
+                            };
+                            tracing::debug!(%request_id, "dispatching callback result (suspend)");
+                            CallbackResult::Suspend(reason)
+                        } else {
+                            match resp.result {
+                                Some(callback_response::Result::JsonResult(json)) => {
+                                    tracing::debug!(%request_id, "dispatching callback result (ok)");
+                                    CallbackResult::Ok(json)
+                                }
+                                Some(callback_response::Result::Error(err)) => {
+                                    tracing::debug!(%request_id, "dispatching callback result (error)");
+                                    CallbackResult::Err(err)
+                                }
+                                None => {
+                                    tracing::debug!(%request_id, "dispatching callback result (empty)");
+                                    CallbackResult::Err("empty callback response".to_string())
+                                }
                             }
                         };
                         callbacks::dispatch_callback_response(
@@ -418,6 +431,8 @@ impl crate::proto::eryx::v1::eryx_server::Eryx for EryxService {
                             result_error: String::new(),
                             failure_kind: FailureKind::Cancelled as i32,
                             callback_journal: None,
+                            suspended: false,
+                            suspended_callback: None,
                         }
                     }
                 };
@@ -860,18 +875,21 @@ async fn execute_with_session(
     let (streamed_stdout, streamed_stderr) = output_accumulator.await.unwrap_or_default();
 
     // Extract the recorded replay journal. Read regardless of success/failure so
-    // the caller can replay completed callbacks even when a later one errored.
-    let (proto_journal, replayed_callbacks) = match &replay_state {
+    // the caller can replay completed callbacks even when a later one errored or
+    // suspended. The suspension metadata (if any) is read from the same guard.
+    let (proto_journal, replayed_callbacks, suspended_callback) = match &replay_state {
         Some(state) => {
             let guard = state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let mut journal = crate::replay::journal_to_proto(&guard.build_journal(params.code));
             params.journal_signer.sign(&mut journal, params.code);
-            (Some(journal), guard.replayed_count())
+            let suspended = guard.suspended().map(crate::replay::suspended_to_proto);
+            (Some(journal), guard.replayed_count(), suspended)
         }
-        None => (None, 0),
+        None => (None, 0, None),
     };
+    let suspended = suspended_callback.is_some();
 
     // Snapshot state after execution (only when persistence is requested).
     let snapshot_bytes = if params.state.is_some() {
@@ -959,6 +977,8 @@ async fn execute_with_session(
                 result_error,
                 failure_kind: FailureKind::Unspecified as i32,
                 callback_journal: proto_journal,
+                suspended,
+                suspended_callback,
             }
         }
         Err(e) => {
@@ -1022,6 +1042,8 @@ async fn execute_with_session(
                 result_error: String::new(),
                 failure_kind: failure_kind as i32,
                 callback_journal: proto_journal,
+                suspended,
+                suspended_callback,
             }
         }
     }

--- a/crates/eryx-server/tests/grpc_e2e.rs
+++ b/crates/eryx-server/tests/grpc_e2e.rs
@@ -1693,3 +1693,178 @@ print("should not reach here")
         "callback after the suspension point must not be dispatched to the client"
     );
 }
+
+/// A client may reply CALLBACK_OUTCOME_SUSPEND even when the request did NOT opt
+/// into replay (no `callback_journal`). The result must still report the
+/// suspension — `suspended` true, `failure_kind` SUSPENDED, the reason carried —
+/// rather than being mis-surfaced as an ordinary sandbox error.
+#[tokio::test]
+async fn suspend_without_replay_opt_in_is_reported_as_suspended() {
+    use eryx_server::proto::eryx::v1::FailureKind;
+
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    let code = r#"
+b = await approve(amount=100)
+print("should not reach here")
+"#;
+    let approve_decl = CallbackDeclaration {
+        name: "approve".to_string(),
+        description: "Requires approval".to_string(),
+        parameters: vec![ParameterDeclaration {
+            name: "amount".to_string(),
+            json_type: "integer".to_string(),
+            description: "Amount to approve".to_string(),
+            required: true,
+        }],
+    };
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                code: code.to_string(),
+                callbacks: vec![approve_decl],
+                // NOTE: no callback_journal — replay/journaling is NOT enabled.
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    while let Some(msg) = stream.message().await.unwrap() {
+        match msg.message {
+            Some(server_message::Message::CallbackRequest(req)) => {
+                assert_eq!(req.name, "approve");
+                tx.send(ClientMessage {
+                    message: Some(client_message::Message::CallbackResponse(
+                        eryx_server::proto::eryx::v1::CallbackResponse {
+                            request_id: req.request_id,
+                            outcome: CallbackOutcome::Suspend as i32,
+                            result: Some(callback_response::Result::Error(
+                                "needs human approval".to_string(),
+                            )),
+                        },
+                    )),
+                })
+                .await
+                .unwrap();
+            }
+            Some(server_message::Message::ExecuteResult(result)) => {
+                assert!(
+                    result.suspended,
+                    "suspension must be reported even without replay opt-in"
+                );
+                assert!(!result.success);
+                assert_eq!(
+                    result.failure_kind,
+                    FailureKind::Suspended as i32,
+                    "suspension must not be classified as a sandbox error"
+                );
+                let suspended = result
+                    .suspended_callback
+                    .expect("suspended_callback should carry the reason");
+                assert_eq!(suspended.reason, "needs human approval");
+                // No journal is returned when replay was not enabled.
+                assert!(
+                    result.callback_journal.is_none(),
+                    "no journal without replay opt-in"
+                );
+                got_result = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(got_result, "never received ExecuteResult");
+}
+
+/// A suspension on a stateful (persist_state) session must NOT attempt a state
+/// snapshot: the guest's fuel is poisoned to 0 by the suspension, so the
+/// snapshot export would trap and yield a misleading empty snapshot. The result
+/// reports the suspension and returns an empty `state_snapshot` cleanly.
+#[tokio::test]
+async fn suspended_stateful_session_skips_snapshot() {
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    let code = r#"
+saved = 42
+b = await approve(amount=100)
+print("should not reach here")
+"#;
+    let approve_decl = CallbackDeclaration {
+        name: "approve".to_string(),
+        description: "Requires approval".to_string(),
+        parameters: vec![ParameterDeclaration {
+            name: "amount".to_string(),
+            json_type: "integer".to_string(),
+            description: "Amount to approve".to_string(),
+            required: true,
+        }],
+    };
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                code: code.to_string(),
+                callbacks: vec![approve_decl],
+                persist_state: true,
+                callback_journal: Some(CallbackJournal {
+                    entries: vec![],
+                    signature: vec![],
+                }),
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    while let Some(msg) = stream.message().await.unwrap() {
+        match msg.message {
+            Some(server_message::Message::CallbackRequest(req)) => {
+                assert_eq!(req.name, "approve");
+                tx.send(ClientMessage {
+                    message: Some(client_message::Message::CallbackResponse(
+                        eryx_server::proto::eryx::v1::CallbackResponse {
+                            request_id: req.request_id,
+                            outcome: CallbackOutcome::Suspend as i32,
+                            result: Some(callback_response::Result::Error(
+                                "needs human approval".to_string(),
+                            )),
+                        },
+                    )),
+                })
+                .await
+                .unwrap();
+            }
+            Some(server_message::Message::ExecuteResult(result)) => {
+                assert!(result.suspended, "execution should be suspended");
+                assert!(
+                    result.state_snapshot.is_empty(),
+                    "no snapshot should be captured for a suspended session"
+                );
+                got_result = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(got_result, "never received ExecuteResult");
+}

--- a/crates/eryx-server/tests/grpc_e2e.rs
+++ b/crates/eryx-server/tests/grpc_e2e.rs
@@ -12,8 +12,8 @@ use eryx::{PoolConfig, Sandbox, SandboxPool};
 use eryx_server::proto::eryx::v1::eryx_client::EryxClient;
 use eryx_server::proto::eryx::v1::eryx_server::EryxServer;
 use eryx_server::proto::eryx::v1::{
-    CallbackDeclaration, CallbackJournal, ClientMessage, ExecuteRequest, ParameterDeclaration,
-    ResourceLimits, callback_response, client_message, server_message,
+    CallbackDeclaration, CallbackJournal, CallbackOutcome, ClientMessage, ExecuteRequest,
+    ParameterDeclaration, ResourceLimits, callback_response, client_message, server_message,
 };
 use eryx_server::service::EryxService;
 use tokio::net::TcpListener;
@@ -473,6 +473,7 @@ print(f"got: {result}")
                     message: Some(client_message::Message::CallbackResponse(
                         eryx_server::proto::eryx::v1::CallbackResponse {
                             request_id: req.request_id,
+                            outcome: 0,
                             result: Some(callback_response::Result::JsonResult(response_json)),
                         },
                     )),
@@ -558,6 +559,7 @@ except Exception as e:
                     message: Some(client_message::Message::CallbackResponse(
                         eryx_server::proto::eryx::v1::CallbackResponse {
                             request_id: req.request_id,
+                            outcome: 0,
                             result: Some(callback_response::Result::Error(
                                 "datasource unavailable".to_string(),
                             )),
@@ -1067,6 +1069,7 @@ print(f"alpha: {result}")
                         message: Some(client_message::Message::CallbackResponse(
                             eryx_server::proto::eryx::v1::CallbackResponse {
                                 request_id: req.request_id,
+                                outcome: 0,
                                 result: Some(callback_response::Result::JsonResult(response_json)),
                             },
                         )),
@@ -1150,6 +1153,7 @@ print(f"beta: {result}")
                         message: Some(client_message::Message::CallbackResponse(
                             eryx_server::proto::eryx::v1::CallbackResponse {
                                 request_id: req.request_id,
+                                outcome: 0,
                                 result: Some(callback_response::Result::JsonResult(response_json)),
                             },
                         )),
@@ -1245,6 +1249,7 @@ print(f"path={result['path']}")
                     message: Some(client_message::Message::CallbackResponse(
                         eryx_server::proto::eryx::v1::CallbackResponse {
                             request_id: req.request_id,
+                            outcome: 0,
                             result: Some(callback_response::Result::JsonResult(response_json)),
                         },
                     )),
@@ -1496,6 +1501,7 @@ print(f"got: {result}")
                     message: Some(client_message::Message::CallbackResponse(
                         eryx_server::proto::eryx::v1::CallbackResponse {
                             request_id: req.request_id,
+                            outcome: 0,
                             result: Some(callback_response::Result::JsonResult(response_json)),
                         },
                     )),
@@ -1571,4 +1577,119 @@ print(f"got: {result}")
     // Keep tx2 alive until the stream ends so the server doesn't see a client
     // disconnect and cancel mid-execution.
     drop(tx2);
+}
+
+/// A client replying with CALLBACK_OUTCOME_SUSPEND stops execution cleanly: the
+/// result reports the suspension (with the suspended callback details), the
+/// guest is halted (fuel poisoned) before any later callback is dispatched, and
+/// the journal of callbacks that completed before the suspension is preserved.
+#[tokio::test]
+async fn callback_suspension_reported_with_prefix_journal() {
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    // `marker` is dispatched *after* `approve` in the script. It must never reach
+    // the client: the suspend gate rejects callbacks initiated after a suspension
+    // and the fuel-poison halt traps the guest before it can dispatch `marker`.
+    let code = r#"
+a = await echo(message="first")
+b = await approve(amount=100)
+c = await marker(message="after-suspend")
+print("should not reach here")
+"#;
+    let approve_decl = CallbackDeclaration {
+        name: "approve".to_string(),
+        description: "Requires approval".to_string(),
+        parameters: vec![ParameterDeclaration {
+            name: "amount".to_string(),
+            json_type: "integer".to_string(),
+            description: "Amount to approve".to_string(),
+            required: true,
+        }],
+    };
+    let marker_decl = CallbackDeclaration {
+        name: "marker".to_string(),
+        description: "Must never be dispatched after suspension".to_string(),
+        parameters: vec![ParameterDeclaration {
+            name: "message".to_string(),
+            json_type: "string".to_string(),
+            description: "The message".to_string(),
+            required: true,
+        }],
+    };
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                code: code.to_string(),
+                callbacks: vec![echo_declaration(), approve_decl, marker_decl],
+                callback_journal: Some(CallbackJournal {
+                    entries: vec![],
+                    signature: vec![],
+                }),
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    let mut marker_dispatched = false;
+    while let Some(msg) = stream.message().await.unwrap() {
+        match msg.message {
+            Some(server_message::Message::CallbackRequest(req)) => {
+                let (outcome, payload) = if req.name == "approve" {
+                    // Defer: signal suspension with an opaque reason.
+                    (
+                        CallbackOutcome::Suspend as i32,
+                        callback_response::Result::Error("needs human approval".to_string()),
+                    )
+                } else {
+                    if req.name == "marker" {
+                        marker_dispatched = true;
+                    }
+                    let response_json = serde_json::json!({ "echoed": "first" }).to_string();
+                    (0, callback_response::Result::JsonResult(response_json))
+                };
+                tx.send(ClientMessage {
+                    message: Some(client_message::Message::CallbackResponse(
+                        eryx_server::proto::eryx::v1::CallbackResponse {
+                            request_id: req.request_id,
+                            outcome,
+                            result: Some(payload),
+                        },
+                    )),
+                })
+                .await
+                .unwrap();
+            }
+            Some(server_message::Message::ExecuteResult(result)) => {
+                assert!(result.suspended, "execution should be suspended");
+                let suspended = result
+                    .suspended_callback
+                    .expect("suspended_callback should be set");
+                assert_eq!(suspended.name, "approve");
+                assert_eq!(suspended.reason, "needs human approval");
+                // Only the completed `echo` callback is journaled.
+                let journal = result.callback_journal.expect("journal returned");
+                assert_eq!(journal.entries.len(), 1);
+                assert_eq!(journal.entries[0].name, "echo");
+                got_result = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(got_result, "never received ExecuteResult");
+    assert!(
+        !marker_dispatched,
+        "callback after the suspension point must not be dispatched to the client"
+    );
 }

--- a/crates/eryx/src/callback.rs
+++ b/crates/eryx/src/callback.rs
@@ -312,6 +312,20 @@ pub enum CallbackError {
     /// variant directly.
     #[error("{0}")]
     Replayed(String),
+
+    /// The callback cannot complete now and asks execution to **suspend**.
+    ///
+    /// Returning this variant defers the work ("retry later"): execution stops
+    /// immediately and Python-blind (the suspending callback poisons the WASM
+    /// fuel, trapping the guest before any further Python runs), the suspension
+    /// is reported to the caller (callback name, arguments, and this opaque
+    /// `reason`), and the journal of callbacks that already completed is returned
+    /// so a later run can replay that prefix and resume.
+    ///
+    /// The `reason` is opaque to eryx — a caller might use it to decide what to
+    /// wait for (e.g. human approval) before re-executing with the journal.
+    #[error("{0}")]
+    Suspend(String),
 }
 
 /// Helper function to create an empty parameters schema (no arguments).

--- a/crates/eryx/src/callback_handler.rs
+++ b/crates/eryx/src/callback_handler.rs
@@ -19,7 +19,9 @@ use crate::net::ConnectionManager;
 use crate::sandbox::ResourceLimits;
 use crate::secrets::SecretConfig;
 use crate::trace::{OutputHandler, TraceEvent, TraceEventKind, TraceHandler};
-use crate::wasm::{CallbackRequest, NetRequest, OutputRequest, TraceRequest, parse_trace_event};
+use crate::wasm::{
+    CallbackHostResult, CallbackRequest, NetRequest, OutputRequest, TraceRequest, parse_trace_event,
+};
 
 /// Type alias for the in-flight callback futures collection.
 type InFlightCallbacks = FuturesUnordered<Pin<Box<dyn Future<Output = ()> + Send>>>;
@@ -98,17 +100,18 @@ fn create_callback_future(
     if let Some(max) = resource_limits.max_callback_invocations
         && current_count >= max
     {
-        let _ = request
-            .response_tx
-            .send(Err(format!("Callback limit exceeded ({max} invocations)")));
+        let _ = request.response_tx.send(CallbackHostResult::Err(format!(
+            "Callback limit exceeded ({max} invocations)"
+        )));
         return None;
     }
 
     // Find the callback
     let Some(callback) = callbacks_map.get(&request.name).cloned() else {
-        let _ = request
-            .response_tx
-            .send(Err(format!("Callback '{}' not found", request.name)));
+        let _ = request.response_tx.send(CallbackHostResult::Err(format!(
+            "Callback '{}' not found",
+            request.name
+        )));
         return None;
     };
 
@@ -116,9 +119,9 @@ fn create_callback_future(
     let args: serde_json::Value = match serde_json::from_str(&request.arguments_json) {
         Ok(v) => v,
         Err(e) => {
-            let _ = request
-                .response_tx
-                .send(Err(format!("Invalid arguments JSON: {e}")));
+            let _ = request.response_tx.send(CallbackHostResult::Err(format!(
+                "Invalid arguments JSON: {e}"
+            )));
             return None;
         }
     };
@@ -137,13 +140,21 @@ fn create_callback_future(
             invoke_future.await
         };
 
-        // Scrub secret placeholders from callback results
+        // Scrub secret placeholders from callback results. A `Suspend` is mapped
+        // to its own host-result variant so the `invoke` import can halt the
+        // guest (it does not surface as an ordinary Python exception path).
         let result = match callback_result {
-            Ok(value) => Ok(crate::secrets::scrub_placeholders(
+            Ok(value) => CallbackHostResult::Ok(crate::secrets::scrub_placeholders(
                 &value.to_string(),
                 &secrets,
             )),
-            Err(e) => Err(crate::secrets::scrub_placeholders(&e.to_string(), &secrets)),
+            Err(CallbackError::Suspend(reason)) => {
+                CallbackHostResult::Suspend(crate::secrets::scrub_placeholders(&reason, &secrets))
+            }
+            Err(e) => CallbackHostResult::Err(crate::secrets::scrub_placeholders(
+                &e.to_string(),
+                &secrets,
+            )),
         };
 
         // Send result back to the Python code

--- a/crates/eryx/src/error.rs
+++ b/crates/eryx/src/error.rs
@@ -75,6 +75,18 @@ pub enum Error {
     #[error("execution cancelled")]
     Cancelled,
 
+    /// Execution was suspended by a callback returning
+    /// [`CallbackError::Suspend`](crate::CallbackError::Suspend).
+    ///
+    /// The guest was halted (its fuel poisoned) the instant the callback
+    /// suspended, so no normal output is produced. This is distinct from
+    /// [`FuelExhausted`](Self::FuelExhausted), which signals a real fuel-limit
+    /// overrun. The opaque reason and the suspended callback's metadata are
+    /// surfaced separately (e.g. via
+    /// [`ReplayOutcome::suspended`](crate::ReplayOutcome::suspended)).
+    #[error("execution suspended: {0}")]
+    Suspended(String),
+
     /// I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/eryx/src/lib.rs
+++ b/crates/eryx/src/lib.rs
@@ -93,6 +93,7 @@ pub use package::{ExtractedPackage, PackageFormat};
 pub use pool::{PoolConfig, PoolError, PoolStats, PooledSandbox, SandboxPool};
 pub use replay::{
     CallbackJournal, CallbackJournalEntry, CallbackOutcome, ReplayCallback, ReplayState,
+    SuspendedCallback,
 };
 pub use sandbox::{
     ExecuteResult, ExecuteStats, ExecutionHandle, ReplayOutcome, ResourceLimits, Sandbox,

--- a/crates/eryx/src/replay.rs
+++ b/crates/eryx/src/replay.rs
@@ -88,9 +88,10 @@
 //! later run replays the recorded prefix. Two layers guarantee no further
 //! callback runs after a suspension:
 //!
-//! 1. A **synchronous gate**: once any callback has suspended, every subsequent
-//!    invocation funneling through [`ReplayState`] is rejected (the internal
-//!    `Decision::AlreadySuspended` path), covering in-flight `gather` siblings.
+//! 1. A **synchronous gate**: once any callback has suspended, every callback
+//!    *dispatched after* that point funneling through [`ReplayState`] is rejected
+//!    (the internal `Decision::AlreadySuspended` path), covering later `gather`
+//!    siblings.
 //! 2. The **fuel-poison halt** in the host import, which traps the guest before
 //!    it can dispatch any further callback or perform I/O.
 //!
@@ -240,6 +241,12 @@ pub struct ReplayState {
     /// set, every subsequent invocation is rejected (`Decision::AlreadySuspended`)
     /// so no further callback runs after a suspension.
     suspended: Option<SuspendedCallback>,
+    /// Initiation sequence of the suspending callback, if any. Concurrently
+    /// dispatched siblings (e.g. an `asyncio.gather` batch) reserve sequence
+    /// numbers around the suspending call and may complete and record *after* it;
+    /// the built journal drops every entry at or after this sequence so it is a
+    /// clean prefix that ends before the suspension point.
+    suspend_seq: Option<usize>,
     /// How many invocations were served from the previous journal.
     replayed_count: u32,
 }
@@ -258,8 +265,10 @@ enum Decision {
     /// any callback the guest dispatches *after* the suspension is rejected here.
     /// Fuel poisoning already halts the guest synchronously at the suspending
     /// callback's import, so in practice no further callback is dispatched; this
-    /// gate is a belt-and-suspenders guard that also covers in-flight siblings of
-    /// a concurrent `asyncio.gather` batch whose futures were already pending.
+    /// gate is a belt-and-suspenders guard that also rejects any concurrent
+    /// `asyncio.gather` sibling dispatched *after* the suspension is recorded. (A
+    /// sibling that was already past `decide` completes and is journaled normally;
+    /// `build_journal` then truncates it back out of the recorded prefix.)
     AlreadySuspended,
 }
 
@@ -286,6 +295,7 @@ impl ReplayState {
             next_seq: 0,
             entries: Vec::new(),
             suspended: None,
+            suspend_seq: None,
             replayed_count: 0,
         }
     }
@@ -353,11 +363,14 @@ impl ReplayState {
         self.entries[seq] = Some(entry);
     }
 
-    /// Record that a callback suspended. Only the first suspension is kept; the
-    /// suspended call itself is *not* journaled (so it re-runs live on resume).
-    fn record_suspend(&mut self, suspended: SuspendedCallback) {
+    /// Record that a callback suspended at initiation sequence `seq`. Only the
+    /// first suspension is kept; the suspended call itself is *not* journaled (so
+    /// it re-runs live on resume). The sequence is remembered so `build_journal`
+    /// can truncate entries recorded by concurrent siblings after this point.
+    fn record_suspend(&mut self, seq: usize, suspended: SuspendedCallback) {
         if self.suspended.is_none() {
             self.suspended = Some(suspended);
+            self.suspend_seq = Some(seq);
         }
     }
 
@@ -376,12 +389,27 @@ impl ReplayState {
     /// Build the journal recorded during this run for the given script.
     ///
     /// Reserved-but-unrecorded slots (e.g. in-flight callbacks) are dropped;
-    /// recorded entries keep their dispatch-order positions.
+    /// recorded entries keep their dispatch-order positions. If a callback
+    /// suspended, entries initiated at or after the suspending call are also
+    /// dropped — a concurrently dispatched sibling may have completed and
+    /// recorded around the suspension point, but the journal must be a clean
+    /// prefix that ends before the suspension so a later run replays only what
+    /// truly preceded it.
     #[must_use]
     pub fn build_journal(&self, code: impl Into<String>) -> CallbackJournal {
+        let entries = self
+            .entries
+            .iter()
+            .flatten()
+            .filter(|entry| match self.suspend_seq {
+                Some(seq) => (entry.index as usize) < seq,
+                None => true,
+            })
+            .cloned()
+            .collect();
         CallbackJournal {
             code: code.into(),
-            entries: self.entries.iter().flatten().cloned().collect(),
+            entries,
         }
     }
 }
@@ -485,11 +513,14 @@ impl Callback for ReplayCallback {
                             // Do not journal a suspended callback: only record
                             // that it suspended so the caller can act on it. The
                             // call re-runs live when execution resumes.
-                            lock_state(&state).record_suspend(SuspendedCallback {
-                                name,
-                                args_json,
-                                reason,
-                            });
+                            lock_state(&state).record_suspend(
+                                seq,
+                                SuspendedCallback {
+                                    name,
+                                    args_json,
+                                    reason,
+                                },
+                            );
                         }
                     }
                     result
@@ -961,6 +992,43 @@ mod tests {
         // Nothing new journaled by the rejected call.
         let st = lock_state(&state);
         assert!(st.build_journal("code").is_empty());
+    }
+
+    #[test]
+    fn build_journal_truncates_entries_after_suspend_point() {
+        // Three callbacks are dispatched concurrently, reserving seq 0, 1, 2. The
+        // seq-0 and seq-2 calls complete and record; the seq-1 call suspends. The
+        // built journal must be a clean prefix: only the entry initiated *before*
+        // the suspending call (seq 0) is kept. The seq-2 sibling that happened to
+        // complete around the suspension is dropped, so a later resume does not
+        // replay/skip a callback that logically followed the suspension point.
+        let mut st = ReplayState::new(CallbackJournal::new("code"));
+        let args = json!({});
+        let h = fnv1a_64(canonical_json(&args).as_bytes());
+
+        assert!(matches!(st.decide("a", h, "{}"), Decision::Miss { seq: 0 }));
+        assert!(matches!(st.decide("b", h, "{}"), Decision::Miss { seq: 1 }));
+        assert!(matches!(st.decide("c", h, "{}"), Decision::Miss { seq: 2 }));
+
+        st.record_live(entry_ok(0, "a", &args, json!("a-done")));
+        st.record_live(entry_ok(2, "c", &args, json!("c-done")));
+        st.record_suspend(
+            1,
+            SuspendedCallback {
+                name: "b".into(),
+                args_json: "{}".into(),
+                reason: "wait".into(),
+            },
+        );
+
+        let journal = st.build_journal("code");
+        assert_eq!(
+            journal.entries.len(),
+            1,
+            "only the pre-suspend prefix is kept"
+        );
+        assert_eq!(journal.entries[0].index, 0);
+        assert_eq!(journal.entries[0].name, "a");
     }
 
     #[tokio::test]

--- a/crates/eryx/src/replay.rs
+++ b/crates/eryx/src/replay.rs
@@ -78,6 +78,22 @@
 //! code. The wrapper consults a shared [`ReplayState`] before delegating to the
 //! real callback.
 //!
+//! # Suspension
+//!
+//! A callback can return [`CallbackError::Suspend`] to defer its work
+//! ("retry later"). When that happens the wrapper records a [`SuspendedCallback`]
+//! (name, args, opaque reason) but does **not** journal the call, and the
+//! suspension propagates back to the host import, which poisons the WASM fuel to
+//! halt the guest synchronously. The suspended call therefore re-runs live when a
+//! later run replays the recorded prefix. Two layers guarantee no further
+//! callback runs after a suspension:
+//!
+//! 1. A **synchronous gate**: once any callback has suspended, every subsequent
+//!    invocation funneling through [`ReplayState`] is rejected (the internal
+//!    `Decision::AlreadySuspended` path), covering in-flight `gather` siblings.
+//! 2. The **fuel-poison halt** in the host import, which traps the guest before
+//!    it can dispatch any further callback or perform I/O.
+//!
 //! # Security: journal trust boundary
 //!
 //! Replayed journal entries are returned to Python code as-is — eryx does not
@@ -102,10 +118,12 @@ use crate::schema::Schema;
 
 /// The outcome of a callback invocation, as understood by replay.
 ///
-/// This mirrors what a callback can communicate back through the
-/// [`Callback`] trait: a success value or a permanent error. Both
-/// [`CallbackOutcome::Ok`] and [`CallbackOutcome::Err`] are journaled so that a
-/// later replay reproduces the same result.
+/// This mirrors what a callback can communicate back through the [`Callback`]
+/// trait: a success value, a permanent error, or a request to suspend. Only
+/// [`CallbackOutcome::Ok`] and [`CallbackOutcome::Err`] are ever journaled so a
+/// later replay reproduces the same result; [`CallbackOutcome::Suspend`]
+/// terminates execution before an entry is recorded, so the suspended call is
+/// re-attempted live on the resuming run.
 #[derive(Debug, Clone)]
 pub enum CallbackOutcome {
     /// The callback succeeded. The value is returned to Python and journaled.
@@ -113,6 +131,10 @@ pub enum CallbackOutcome {
     /// The callback failed permanently. Python receives an exception and the
     /// error is journaled (so a later replay reproduces the same failure).
     Err(String),
+    /// The callback asked to suspend (via [`CallbackError::Suspend`]). Execution
+    /// stops, the suspension is surfaced to the caller, and nothing is journaled
+    /// for this call. The reason string is opaque to eryx.
+    Suspend(String),
 }
 
 impl CallbackOutcome {
@@ -120,6 +142,7 @@ impl CallbackOutcome {
     fn from_invoke(result: &Result<serde_json::Value, CallbackError>) -> Self {
         match result {
             Ok(value) => Self::Ok(value.clone()),
+            Err(CallbackError::Suspend(reason)) => Self::Suspend(reason.clone()),
             Err(other) => Self::Err(other.to_string()),
         }
     }
@@ -173,6 +196,21 @@ impl CallbackJournal {
     }
 }
 
+/// Details of the callback that suspended execution.
+///
+/// Recorded when a callback returns [`CallbackError::Suspend`]; surfaced to the
+/// caller (e.g. via [`ReplayOutcome::suspended`](crate::ReplayOutcome::suspended))
+/// so it can act on the reason and later resume by re-executing with the journal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SuspendedCallback {
+    /// Name of the callback that suspended.
+    pub name: String,
+    /// Canonicalized arguments JSON the callback was invoked with.
+    pub args_json: String,
+    /// The opaque reason string the callback returned.
+    pub reason: String,
+}
+
 /// Mutable replay state shared across all wrapped callbacks in one execution.
 ///
 /// A single state is shared (behind a mutex) by every [`ReplayCallback`] in an
@@ -196,8 +234,12 @@ pub struct ReplayState {
     /// only an entry index/order tag — matching no longer depends on it.
     next_seq: usize,
     /// Entries recorded for *this* execution, indexed by sequence number.
-    /// `None` marks a reserved-but-unrecorded slot (in-flight).
+    /// `None` marks a reserved-but-unrecorded slot (in-flight or suspended).
     entries: Vec<Option<CallbackJournalEntry>>,
+    /// Set if a callback suspended; only the first suspension is recorded. Once
+    /// set, every subsequent invocation is rejected (`Decision::AlreadySuspended`)
+    /// so no further callback runs after a suspension.
+    suspended: Option<SuspendedCallback>,
     /// How many invocations were served from the previous journal.
     replayed_count: u32,
 }
@@ -208,6 +250,17 @@ enum Decision {
     Hit(Result<serde_json::Value, String>),
     /// Not in the journal (key absent or exhausted); invoke live and record at `seq`.
     Miss { seq: usize },
+    /// A previous callback already suspended; reject this invocation without
+    /// invoking the real callback or recording anything.
+    ///
+    /// This is the deterministic guarantee that no side-effecting callback runs
+    /// after a suspension: because every invocation funnels through `decide`,
+    /// any callback the guest dispatches *after* the suspension is rejected here.
+    /// Fuel poisoning already halts the guest synchronously at the suspending
+    /// callback's import, so in practice no further callback is dispatched; this
+    /// gate is a belt-and-suspenders guard that also covers in-flight siblings of
+    /// a concurrent `asyncio.gather` batch whose futures were already pending.
+    AlreadySuspended,
 }
 
 impl ReplayState {
@@ -232,6 +285,7 @@ impl ReplayState {
             live_mode: false,
             next_seq: 0,
             entries: Vec::new(),
+            suspended: None,
             replayed_count: 0,
         }
     }
@@ -246,6 +300,13 @@ impl ReplayState {
     /// the sticky divergence guard, after which every invocation runs live so a
     /// later same-key call cannot replay a now-stale result.
     fn decide(&mut self, name: &str, args_hash: u64, args_json: &str) -> Decision {
+        // Once any callback has suspended, reject every subsequent invocation
+        // without invoking the real callback or recording anything. No seq is
+        // reserved, so the rejected call leaves no hole in the journal.
+        if self.suspended.is_some() {
+            return Decision::AlreadySuspended;
+        }
+
         let seq = self.next_seq;
         self.next_seq += 1;
         self.ensure_slot(seq);
@@ -290,6 +351,20 @@ impl ReplayState {
         let seq = entry.index as usize;
         self.ensure_slot(seq);
         self.entries[seq] = Some(entry);
+    }
+
+    /// Record that a callback suspended. Only the first suspension is kept; the
+    /// suspended call itself is *not* journaled (so it re-runs live on resume).
+    fn record_suspend(&mut self, suspended: SuspendedCallback) {
+        if self.suspended.is_none() {
+            self.suspended = Some(suspended);
+        }
+    }
+
+    /// The callback that suspended this execution, if any.
+    #[must_use]
+    pub fn suspended(&self) -> Option<&SuspendedCallback> {
+        self.suspended.as_ref()
     }
 
     /// Number of invocations served from the previous journal.
@@ -366,6 +441,11 @@ impl Callback for ReplayCallback {
         let decision = lock_state(&self.state).decide(&name, args_hash, &args_json);
 
         match decision {
+            Decision::AlreadySuspended => Box::pin(async {
+                Err(CallbackError::Suspend(
+                    "execution already suspended by a previous callback".into(),
+                ))
+            }),
             Decision::Hit(result) => {
                 let invoke_result = match result {
                     Ok(value) => Ok(value),
@@ -399,6 +479,16 @@ impl Callback for ReplayCallback {
                                 args_hash,
                                 args_json,
                                 result: Err(message),
+                            });
+                        }
+                        CallbackOutcome::Suspend(reason) => {
+                            // Do not journal a suspended callback: only record
+                            // that it suspended so the caller can act on it. The
+                            // call re-runs live when execution resumes.
+                            lock_state(&state).record_suspend(SuspendedCallback {
+                                name,
+                                args_json,
+                                reason,
                             });
                         }
                     }
@@ -488,6 +578,7 @@ mod tests {
     enum Outcome {
         Ok(serde_json::Value),
         Err(String),
+        Suspend(String),
     }
 
     impl Callback for ProgrammableCallback {
@@ -511,6 +602,7 @@ mod tests {
                 match outcome {
                     Outcome::Ok(v) => Ok(v),
                     Outcome::Err(m) => Err(CallbackError::ExecutionFailed(m)),
+                    Outcome::Suspend(r) => Err(CallbackError::Suspend(r)),
                 }
             })
         }
@@ -810,5 +902,99 @@ mod tests {
             journal.entries[0].result,
             Err("execution failed: boom".to_string())
         );
+    }
+
+    // ---- suspension ---------------------------------------------------------
+
+    #[test]
+    fn outcome_classifies_suspend() {
+        assert!(matches!(
+            CallbackOutcome::from_invoke(&Err(CallbackError::Suspend("wait".into()))),
+            CallbackOutcome::Suspend(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn suspend_records_metadata_without_journaling() {
+        // The replay layer records the suspension metadata and does NOT journal
+        // the suspended callback (the actual guest halt is the fuel-poison in the
+        // host import, exercised by the integration tests).
+        let state = Arc::new(Mutex::new(ReplayState::new(CallbackJournal::new("code"))));
+
+        let (suspender, suspend_calls) = programmable("approve", Outcome::Suspend("wait".into()));
+        let suspend_wrapper = ReplayCallback::new(suspender, Arc::clone(&state));
+        let err = suspend_wrapper.invoke(json!({"id": 5})).await.unwrap_err();
+        assert!(matches!(err, CallbackError::Suspend(_)));
+        assert_eq!(suspend_calls.load(Ordering::SeqCst), 1);
+
+        let st = lock_state(&state);
+        let suspended = st.suspended().expect("suspension should be recorded");
+        assert_eq!(suspended.name, "approve");
+        assert_eq!(suspended.reason, "wait");
+        assert!(
+            st.build_journal("code").is_empty(),
+            "suspended callback must not be journaled"
+        );
+    }
+
+    #[tokio::test]
+    async fn callbacks_dispatched_after_suspension_are_rejected() {
+        // A callback the guest dispatches *after* the suspension is recorded
+        // (e.g. an in-flight gather sibling) must be rejected without invoking
+        // the real callback — deterministically, the gate alongside fuel-poison.
+        let state = Arc::new(Mutex::new(ReplayState::new(CallbackJournal::new("code"))));
+
+        let (suspender, _) = programmable("approve", Outcome::Suspend("wait".into()));
+        let suspend_wrapper = ReplayCallback::new(suspender, Arc::clone(&state));
+        let _ = suspend_wrapper.invoke(json!({})).await;
+
+        let (fetch, fetch_calls) = programmable("fetch", Outcome::Ok(json!("live")));
+        let fetch_wrapper = ReplayCallback::new(fetch, Arc::clone(&state));
+        let err = fetch_wrapper.invoke(json!({})).await.unwrap_err();
+        assert!(matches!(err, CallbackError::Suspend(_)));
+        assert_eq!(
+            fetch_calls.load(Ordering::SeqCst),
+            0,
+            "callback dispatched after suspension must not run"
+        );
+
+        // Nothing new journaled by the rejected call.
+        let st = lock_state(&state);
+        assert!(st.build_journal("code").is_empty());
+    }
+
+    #[tokio::test]
+    async fn resume_replays_prefix_and_reruns_suspended_call_live() {
+        // Run 1 completed `fetch` (journaled) then `approve` suspended (not
+        // journaled). On resume the journal has only `fetch`; keyed matching
+        // replays it from cache while `approve` runs live again.
+        let fetch_args = json!({"q": "x"});
+        let previous = CallbackJournal {
+            code: "code".into(),
+            entries: vec![entry_ok(0, "fetch", &fetch_args, json!("cached"))],
+        };
+        let state = Arc::new(Mutex::new(ReplayState::new(previous)));
+
+        // `fetch` replays from cache (not invoked live).
+        let (fetch, fetch_calls) = programmable("fetch", Outcome::Ok(json!("LIVE")));
+        let fetch_wrapper = ReplayCallback::new(fetch, Arc::clone(&state));
+        let rf = fetch_wrapper.invoke(fetch_args.clone()).await.unwrap();
+        assert_eq!(rf, json!("cached"), "fetch replayed from cache");
+        assert_eq!(
+            fetch_calls.load(Ordering::SeqCst),
+            0,
+            "fetch not re-invoked"
+        );
+
+        // `approve` is not in the journal -> runs live, and this time succeeds.
+        let (approve, approve_calls) = programmable("approve", Outcome::Ok(json!("approved")));
+        let approve_wrapper = ReplayCallback::new(approve, Arc::clone(&state));
+        let ra = approve_wrapper.invoke(json!({})).await.unwrap();
+        assert_eq!(ra, json!("approved"));
+        assert_eq!(approve_calls.load(Ordering::SeqCst), 1, "approve runs live");
+
+        let st = lock_state(&state);
+        assert_eq!(st.replayed_count(), 1, "only fetch replayed");
+        assert!(st.suspended().is_none(), "no suspension on the resume run");
     }
 }

--- a/crates/eryx/src/sandbox.rs
+++ b/crates/eryx/src/sandbox.rs
@@ -11,7 +11,7 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
-use crate::replay::{CallbackJournal, ReplayState, wrap_callbacks};
+use crate::replay::{CallbackJournal, ReplayState, SuspendedCallback, wrap_callbacks};
 
 #[cfg(feature = "native-extensions")]
 use crate::cache::ComponentCache;
@@ -257,6 +257,7 @@ impl Sandbox {
         ReplayOutcome {
             journal: guard.build_journal(code),
             replayed_callbacks: guard.replayed_count(),
+            suspended: guard.suspended().cloned(),
             result,
         }
     }
@@ -2407,16 +2408,28 @@ impl SandboxBuilder<state::Has, state::Has> {
 /// Result of a replay-aware execution via [`Sandbox::execute_with_journal`].
 ///
 /// The [`journal`](Self::journal) is always present — even when
-/// [`result`](Self::result) is an error — so a later resubmission can replay
-/// every callback that completed.
+/// [`result`](Self::result) is an error or the run suspended — so a later
+/// resubmission can replay every callback that completed.
 #[derive(Debug)]
 pub struct ReplayOutcome {
     /// The execution result, exactly as [`Sandbox::execute`] would return it.
+    ///
+    /// When [`suspended`](Self::suspended) is `Some`, this is `Err` — the guest
+    /// was halted (its fuel poisoned) the instant the callback suspended, so
+    /// there is no normal output. Callers should branch on `suspended` first and
+    /// treat this error as the expected consequence of a suspension rather than a
+    /// failure.
     pub result: Result<ExecuteResult, Error>,
-    /// The callback journal recorded during this run, in initiation order.
+    /// The callback journal recorded during this run, in initiation order. The
+    /// suspended callback itself is *not* recorded, so it re-runs live on resume.
     pub journal: CallbackJournal,
     /// How many callbacks were served from the previous journal (cache hits).
     pub replayed_callbacks: u32,
+    /// Set when a callback requested suspension via
+    /// [`CallbackError::Suspend`](crate::CallbackError::Suspend). Carries the
+    /// callback name, arguments, and opaque reason so the caller can decide what
+    /// to wait for before resuming with [`journal`](Self::journal).
+    pub suspended: Option<SuspendedCallback>,
 }
 
 /// Result of executing Python code in the sandbox.

--- a/crates/eryx/src/session/executor.rs
+++ b/crates/eryx/src/session/executor.rs
@@ -988,6 +988,9 @@ impl SessionExecutor {
             state.set_output_tx(output_tx);
             state.set_callbacks(callback_infos);
             state.reset_memory_tracker();
+            // A reused store keeps its ExecutorState across runs; clear any stale
+            // suspension flag so it does not misclassify this run's trap.
+            state.clear_suspended();
         }
 
         self.execution_count += 1;
@@ -1077,6 +1080,11 @@ impl SessionExecutor {
         }
 
         // Clear channels after execution and capture peak memory
+        // Capture any suspension reason before the store is restored: a callback
+        // that suspended poisons fuel to halt the guest, so the resulting trap
+        // must be classified as a suspension rather than fuel-limit exhaustion.
+        let suspended_reason = store.data().suspended.clone();
+
         let peak_memory = {
             let state = store.data_mut();
             state.set_callback_tx(None);
@@ -1105,9 +1113,13 @@ impl SessionExecutor {
             {
                 Error::Timeout(execution_timeout.unwrap_or_default())
             } else if e.downcast_ref::<wasmtime::Trap>() == Some(&wasmtime::Trap::OutOfFuel) {
-                let consumed = initial_fuel.saturating_sub(remaining_fuel);
-                let limit = fuel_limit.unwrap_or(u64::MAX);
-                Error::FuelExhausted { consumed, limit }
+                if let Some(reason) = suspended_reason.clone() {
+                    Error::Suspended(reason)
+                } else {
+                    let consumed = initial_fuel.saturating_sub(remaining_fuel);
+                    let limit = fuel_limit.unwrap_or(u64::MAX);
+                    Error::FuelExhausted { consumed, limit }
+                }
             } else {
                 Error::Execution(format!("WASM execution error: {e:?}"))
             }
@@ -1498,6 +1510,7 @@ impl ExecutorState {
             memory_tracker,
             net_tx: None,    // Set via with_network() when network handler is running
             output_tx: None, // Set via set_output_tx() when output handler is running
+            suspended: None,
         }
     }
 
@@ -1522,6 +1535,7 @@ impl ExecutorState {
             net_tx: None,    // Set via with_network() when network handler is running
             output_tx: None, // Set via set_output_tx() when output handler is running
             hybrid_vfs_ctx,
+            suspended: None,
         }
     }
 
@@ -1551,6 +1565,15 @@ impl ExecutorState {
     /// Update the available callbacks for a new execution.
     pub(crate) fn set_callbacks(&mut self, callbacks: Vec<HostCallbackInfo>) {
         self.callbacks = callbacks;
+    }
+
+    /// Clear any suspension flag left over from a previous execution.
+    ///
+    /// A reused session [`Store`] keeps its [`ExecutorState`] across runs, so the
+    /// suspension flag must be cleared before each execution to avoid a stale
+    /// suspension classifying a fresh run's trap.
+    pub(crate) fn clear_suspended(&mut self) {
+        self.suspended = None;
     }
 
     /// Get the peak memory usage from the tracker.

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -34,12 +34,29 @@ use crate::cache::{CacheKey, InstancePreCache};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use wasmtime::component::{Accessor, Component, HasSelf, Linker, ResourceTable};
-use wasmtime::{Config, Engine, ResourceLimiter, Store};
+use wasmtime::{AsContextMut, Config, Engine, ResourceLimiter, Store};
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 use crate::callback::Callback;
 use crate::error::Error;
 use crate::trace::TraceEvent;
+
+/// The result a callback handler sends back to the `invoke` host import.
+///
+/// Distinguishes a successful result and an ordinary error (both surface to
+/// Python as a value / exception and let execution continue) from a
+/// **suspension**, which causes the import to poison the store's fuel and halt
+/// the guest synchronously.
+#[derive(Debug, Clone)]
+pub enum CallbackHostResult {
+    /// The callback succeeded; the JSON value is returned to Python.
+    Ok(String),
+    /// The callback failed; the message is raised as an exception in Python.
+    Err(String),
+    /// The callback asked to suspend. The import poisons fuel to halt the guest;
+    /// the string is the opaque reason recorded for the caller.
+    Suspend(String),
+}
 
 /// Request to invoke a callback from Python code.
 #[derive(Debug)]
@@ -49,7 +66,7 @@ pub struct CallbackRequest {
     /// JSON-encoded arguments.
     pub arguments_json: String,
     /// Channel to send the response back.
-    pub response_tx: oneshot::Sender<std::result::Result<String, String>>,
+    pub response_tx: oneshot::Sender<CallbackHostResult>,
 }
 
 /// Request to report a trace event from Python code.
@@ -431,6 +448,13 @@ pub struct ExecutorState {
     /// Uses ScrubbingStorage to scrub secret placeholders from file writes.
     #[cfg(feature = "vfs")]
     pub(crate) hybrid_vfs_ctx: Option<eryx_vfs::HybridVfsCtx<eryx_vfs::ArcStorage>>,
+    /// Set when a callback requested suspension (`CallbackError::Suspend`).
+    ///
+    /// The callback import sets this synchronously and poisons the store's fuel
+    /// to `0`, which traps the guest at its next fuel-metered instruction. The
+    /// flag both gates further host effects (network / VFS / output) and lets the
+    /// trap be classified as a suspension rather than a fuel-limit exhaustion.
+    pub(crate) suspended: Option<String>,
 }
 
 impl std::fmt::Debug for ExecutorState {
@@ -507,10 +531,28 @@ impl SandboxImportsWithStore for HasSelf<ExecutorState> {
                 if tx.send(request).await.is_err() {
                     Err("Callback channel closed".to_string())
                 } else {
-                    // Wait for response
-                    response_rx
-                        .await
-                        .unwrap_or_else(|_| Err("Callback response channel closed".to_string()))
+                    // Wait for the handler's response.
+                    match response_rx.await {
+                        Ok(CallbackHostResult::Ok(value)) => Ok(value),
+                        Ok(CallbackHostResult::Err(message)) => Err(message),
+                        Ok(CallbackHostResult::Suspend(reason)) => {
+                            // Suspension is a synchronous callback-boundary event:
+                            // poison the store's fuel to 0 so the guest traps at
+                            // its next fuel-metered instruction — Python cannot run
+                            // any further code, dispatch callbacks, or perform I/O
+                            // afterwards. The host-side flag records the reason and
+                            // drives trap classification plus the net/VFS/output
+                            // gates.
+                            accessor.with(|mut access| {
+                                access.get().suspended = Some(reason.clone());
+                                let _ = access.as_context_mut().set_fuel(0);
+                            });
+                            // The return value is moot: the guest traps before it
+                            // can observe it. Surface the reason for completeness.
+                            Err(reason)
+                        }
+                        Err(_) => Err("Callback response channel closed".to_string()),
+                    }
                 }
             } else {
                 // No callback channel - return error
@@ -548,6 +590,10 @@ impl SandboxImports for ExecutorState {
 
     /// Report output (stdout/stderr) to the host in real-time.
     fn report_output(&mut self, stream_id: u32, data: String) {
+        // Drop output once suspended: no side effects after a suspension.
+        if self.suspended.is_some() {
+            return;
+        }
         if let Some(tx) = &self.output_tx {
             let request = OutputRequest {
                 stream: stream_id,
@@ -601,6 +647,10 @@ impl tcp::Host for ExecutorState {
     ) -> Result<u32, tcp::TcpError> {
         tracing::debug!(host = %host, port, timeout_ms, "TCP connect requested");
 
+        if self.suspended.is_some() {
+            return Err(tcp::TcpError::NotPermitted("execution suspended".into()));
+        }
+
         let tx = self.net_tx.clone().ok_or_else(|| {
             tcp::TcpError::NotPermitted("networking not enabled for this sandbox".into())
         })?;
@@ -634,6 +684,10 @@ impl tcp::Host for ExecutorState {
     ) -> Result<Vec<u8>, tcp::TcpError> {
         tracing::trace!(handle, len, timeout_ms, "TCP read requested");
 
+        if self.suspended.is_some() {
+            return Err(tcp::TcpError::NotPermitted("execution suspended".into()));
+        }
+
         let tx = self.net_tx.clone().ok_or_else(|| {
             tcp::TcpError::NotPermitted("networking not enabled for this sandbox".into())
         })?;
@@ -664,6 +718,10 @@ impl tcp::Host for ExecutorState {
         data: Vec<u8>,
     ) -> Result<u32, tcp::TcpError> {
         tracing::trace!(handle, len = data.len(), timeout_ms, "TCP write requested");
+
+        if self.suspended.is_some() {
+            return Err(tcp::TcpError::NotPermitted("execution suspended".into()));
+        }
 
         let tx = self.net_tx.clone().ok_or_else(|| {
             tcp::TcpError::NotPermitted("networking not enabled for this sandbox".into())
@@ -710,6 +768,12 @@ impl tls::Host for ExecutorState {
     ) -> Result<u32, tls::TlsError> {
         tracing::debug!(tcp_handle, hostname = %hostname, timeout_ms, "TLS upgrade requested");
 
+        if self.suspended.is_some() {
+            return Err(tls::TlsError::Tcp(tcp::TcpError::NotPermitted(
+                "execution suspended".into(),
+            )));
+        }
+
         let tx = self.net_tx.clone().ok_or_else(|| {
             tls::TlsError::Tcp(tcp::TcpError::NotPermitted(
                 "networking not enabled for this sandbox".into(),
@@ -749,6 +813,12 @@ impl tls::Host for ExecutorState {
     ) -> Result<Vec<u8>, tls::TlsError> {
         tracing::trace!(handle, len, timeout_ms, "TLS read requested");
 
+        if self.suspended.is_some() {
+            return Err(tls::TlsError::Tcp(tcp::TcpError::NotPermitted(
+                "execution suspended".into(),
+            )));
+        }
+
         let tx = self.net_tx.clone().ok_or_else(|| {
             tls::TlsError::Tcp(tcp::TcpError::NotPermitted(
                 "networking not enabled for this sandbox".into(),
@@ -787,6 +857,12 @@ impl tls::Host for ExecutorState {
         data: Vec<u8>,
     ) -> Result<u32, tls::TlsError> {
         tracing::trace!(handle, len = data.len(), timeout_ms, "TLS write requested");
+
+        if self.suspended.is_some() {
+            return Err(tls::TlsError::Tcp(tcp::TcpError::NotPermitted(
+                "execution suspended".into(),
+            )));
+        }
 
         let tx = self.net_tx.clone().ok_or_else(|| {
             tls::TlsError::Tcp(tcp::TcpError::NotPermitted(
@@ -2157,6 +2233,7 @@ impl PythonExecutor {
             output_tx,
             #[cfg(feature = "vfs")]
             hybrid_vfs_ctx,
+            suspended: None,
         };
 
         // Create store for this execution
@@ -2305,10 +2382,18 @@ impl PythonExecutor {
                     Error::Timeout(execution_timeout.unwrap_or_default())
                 }
             } else if e.downcast_ref::<wasmtime::Trap>() == Some(&wasmtime::Trap::OutOfFuel) {
-                let remaining = store.get_fuel().unwrap_or(0);
-                let consumed = initial_fuel.saturating_sub(remaining);
-                let limit = fuel_limit.unwrap_or(u64::MAX);
-                Error::FuelExhausted { consumed, limit }
+                // A callback that suspended poisons the store's fuel to halt the
+                // guest, which surfaces as an OutOfFuel trap. Classify that as a
+                // suspension rather than a real fuel-limit overrun (the suspended
+                // flag is only set on the suspension path).
+                if let Some(reason) = store.data().suspended.clone() {
+                    Error::Suspended(reason)
+                } else {
+                    let remaining = store.get_fuel().unwrap_or(0);
+                    let consumed = initial_fuel.saturating_sub(remaining);
+                    let limit = fuel_limit.unwrap_or(u64::MAX);
+                    Error::FuelExhausted { consumed, limit }
+                }
             } else {
                 Error::Execution(format!("WASM execution error: {e:?}"))
             }

--- a/crates/eryx/tests/callback_replay.rs
+++ b/crates/eryx/tests/callback_replay.rs
@@ -325,3 +325,197 @@ async fn concurrent_gather_callbacks_replay_regardless_of_order() {
         second_out.stdout
     );
 }
+
+// =============================================================================
+// Suspension test callbacks
+// =============================================================================
+
+/// A callback that suspends on its first `n` live invocations, then (if invoked
+/// again, e.g. after `resume_after` calls) succeeds. Counts live invocations.
+struct SuspendingCallback {
+    name: String,
+    reason: String,
+    live_calls: Arc<AtomicU32>,
+    /// Once live_calls exceeds this, the callback succeeds instead of suspending.
+    resume_after: u32,
+}
+
+impl Callback for SuspendingCallback {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        "Suspends pending approval"
+    }
+    fn parameters_schema(&self) -> Schema {
+        Schema::empty()
+    }
+    fn invoke(
+        &self,
+        _args: Value,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, CallbackError>> + Send + '_>> {
+        let n = self.live_calls.fetch_add(1, Ordering::SeqCst) + 1;
+        let reason = self.reason.clone();
+        let resume_after = self.resume_after;
+        Box::pin(async move {
+            if n > resume_after {
+                Ok(json!({"approved": true}))
+            } else {
+                Err(CallbackError::Suspend(reason))
+            }
+        })
+    }
+}
+
+// =============================================================================
+// Suspension tests
+// =============================================================================
+
+/// Core guarantee: when a callback suspends, the guest is halted (fuel poisoned)
+/// the instant it suspends — a subsequent `marker` callback is NEVER invoked,
+/// and the suspension is surfaced with the callback name and reason.
+#[tokio::test]
+async fn suspend_halts_guest_before_subsequent_callback() {
+    let approve_calls = Arc::new(AtomicU32::new(0));
+    let marker_calls = Arc::new(AtomicU32::new(0));
+
+    let script = r#"
+try:
+    await approve()
+except Exception:
+    pass
+await marker()
+print("AFTER_MARKER")
+"#;
+
+    let sandbox = sandbox_builder()
+        .with_callback(SuspendingCallback {
+            name: "approve".to_string(),
+            reason: "needs human approval".to_string(),
+            live_calls: Arc::clone(&approve_calls),
+            resume_after: u32::MAX, // always suspends
+        })
+        .with_callback(CountingCallback {
+            name: "marker".to_string(),
+            live_calls: Arc::clone(&marker_calls),
+        })
+        .build()
+        .expect("build sandbox");
+
+    let outcome = sandbox.execute_with_journal(script).await;
+
+    assert_eq!(
+        approve_calls.load(Ordering::SeqCst),
+        1,
+        "approve invoked once"
+    );
+    assert_eq!(
+        marker_calls.load(Ordering::SeqCst),
+        0,
+        "marker must NEVER run after a suspension halts the guest"
+    );
+
+    let suspended = outcome
+        .suspended
+        .expect("execution should report suspension");
+    assert_eq!(suspended.name, "approve");
+    assert_eq!(suspended.reason, "needs human approval");
+
+    // The run halts with the dedicated Suspended error (not FuelExhausted).
+    let err = outcome
+        .result
+        .expect_err("suspended run yields an error result");
+    assert!(
+        matches!(err, eryx::Error::Suspended(_)),
+        "expected Error::Suspended, got: {err:?}"
+    );
+
+    // The suspended callback itself is not journaled.
+    assert!(
+        outcome.journal.entries.iter().all(|e| e.name != "approve"),
+        "suspended callback must not be journaled"
+    );
+}
+
+/// Suspend then resume: run 1 completes `fetch` then suspends at `approve`;
+/// persist the journal; run 2 replays `fetch` from cache (keyed) while `approve`
+/// runs live again and now succeeds.
+#[tokio::test]
+async fn suspend_then_resume_replays_completed_prefix() {
+    let fetch_calls = Arc::new(AtomicU32::new(0));
+    let approve_calls = Arc::new(AtomicU32::new(0));
+
+    let script = r#"
+data = await fetch(key="report")
+ok = await approve()
+print(f"fetched={data['live_call']} approved={ok['approved']}")
+"#;
+
+    // ---- Run 1: fetch completes, approve suspends. ----
+    let sandbox = sandbox_builder()
+        .with_callback(CountingCallback {
+            name: "fetch".to_string(),
+            live_calls: Arc::clone(&fetch_calls),
+        })
+        .with_callback(SuspendingCallback {
+            name: "approve".to_string(),
+            reason: "awaiting approval".to_string(),
+            live_calls: Arc::clone(&approve_calls),
+            resume_after: 1, // suspend on first call, succeed afterwards
+        })
+        .build()
+        .expect("build sandbox");
+
+    let first = sandbox.execute_with_journal(script).await;
+    assert_eq!(fetch_calls.load(Ordering::SeqCst), 1, "fetch ran live once");
+    assert_eq!(
+        approve_calls.load(Ordering::SeqCst),
+        1,
+        "approve ran live once"
+    );
+    let suspended = first.suspended.expect("run 1 suspends");
+    assert_eq!(suspended.name, "approve");
+    assert_eq!(
+        first.journal.entries.len(),
+        1,
+        "only fetch journaled; suspended approve is not"
+    );
+    assert_eq!(first.journal.entries[0].name, "fetch");
+
+    // ---- Run 2: resume with the journal. fetch replays, approve runs live. ----
+    let resume_sandbox = sandbox_builder()
+        .with_callback(CountingCallback {
+            name: "fetch".to_string(),
+            live_calls: Arc::clone(&fetch_calls),
+        })
+        .with_callback(SuspendingCallback {
+            name: "approve".to_string(),
+            reason: "awaiting approval".to_string(),
+            live_calls: Arc::clone(&approve_calls),
+            resume_after: 1, // already called once in run 1, so this call succeeds
+        })
+        .with_replay_journal(first.journal)
+        .build()
+        .expect("build resume sandbox");
+
+    let second = resume_sandbox.execute_with_journal(script).await;
+    let output = second.result.expect("resume run succeeds");
+
+    assert!(second.suspended.is_none(), "no suspension on resume");
+    assert_eq!(
+        fetch_calls.load(Ordering::SeqCst),
+        1,
+        "fetch NOT re-invoked — replayed from journal"
+    );
+    assert_eq!(
+        approve_calls.load(Ordering::SeqCst),
+        2,
+        "approve invoked live again on resume"
+    );
+    assert_eq!(second.replayed_callbacks, 1, "fetch replayed");
+    assert!(
+        output.stdout.contains("approved=True"),
+        "approve succeeded on resume, got: {}",
+        output.stdout
+    );
+}


### PR DESCRIPTION
## Summary

Stacked on #228 (`feat/replay-core`). Adds **callback suspension**: a callback can return `CallbackError::Suspend(reason)` to defer ("retry later") instead of completing.

When a callback suspends:
- The suspending callback **import poisons the WASM fuel** (`set_fuel(0)`) so the guest traps at its next fuel-metered instruction — **synchronously and Python-blind**. Python cannot run further code, dispatch more callbacks, or perform network/VFS/output after suspending. This replaces the old epoch-interrupt + `CancellationToken` halt (asynchronous ~10ms ticker, racy) with a synchronous callback-boundary halt.
- Net (`tcp`/`tls`) and `report_output` imports are also gated on the suspended flag as belt-and-suspenders (no side effects in any residual instruction window).
- A synchronous replay gate (`Decision::AlreadySuspended`) rejects any callback the guest dispatches after a suspension, covering in-flight `asyncio.gather` siblings.
- The suspended call is **not journaled**, so it re-runs live on resume; the keyed-FIFO replay of the completed prefix is unchanged.

The suspension surfaces via `ReplayOutcome.suspended` (core) / gRPC `ExecuteResult.suspended` + `suspended_callback` (server), with the prefix journal preserved so a later run replays it and resumes.

## Trap classification

The poisoned-fuel trap is an `OutOfFuel` trap. It is classified as a new `Error::Suspended(reason)` **only when** `ExecutorState.suspended` is set; a real user fuel-limit overrun (flag unset) still reports `Error::FuelExhausted`. Done in both execution paths: `wasm.rs` (`Sandbox::execute_with_journal`) and `session/executor.rs` (the server path). On suspension `ReplayOutcome.result` is `Err(Error::Suspended(_))`; callers branch on `ReplayOutcome.suspended` first.

## Wire compatibility

Proto changes are **additive only** (new field tags, no renumbering): `CallbackResponse.outcome` + `CALLBACK_OUTCOME_SUSPEND`, `ExecuteResult.suspended` + `suspended_callback`, and a `SuspendedCallback` message. Opt-in and backwards-compatible.

## De-risking

The fuel-poison crux was proven first with a throwaway spike (since removed): a script that suspends then calls a `marker` callback never invokes `marker` — `set_fuel(0)` traps the guest reliably under the async `run_concurrent` path. No epoch/ticker fallback was needed.

## Tests

- Unit (`replay.rs`): suspension records metadata + is not journaled; the gate rejects post-suspension callbacks; resume replays the prefix and re-runs the suspended call live.
- Integration (`callback_replay.rs`): **halt proof** (marker never runs, `Error::Suspended`, `suspended` populated) and **suspend → resume** (prefix replayed, suspended call re-run live and succeeds).
- Server e2e (`grpc_e2e.rs`): client replying `CALLBACK_OUTCOME_SUSPEND` yields `ExecuteResult.suspended == true` with `suspended_callback`, the post-suspension callback is never dispatched, and the prefix journal is returned.

All green: `cargo clippy --workspace --all-targets --all-features -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, and `cargo nextest run -p eryx -p eryx-server --features embedded` (473 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)