### PR TITLE
test: cover requests/httpx HTTPS to catch ssl shim regressions

### DIFF
--- a/crates/eryx-python/tests/test_http_libraries.py
+++ b/crates/eryx-python/tests/test_http_libraries.py
@@ -78,6 +78,41 @@ if response.status_code == 200:
             f"Test failed: {result.stdout}\nstderr: {result.stderr}"
         )
 
+    def test_requests_get_https_external(self, requests_sandbox):
+        """Test requests.get() with HTTPS to an external service.
+
+        Regression test for the missing ssl.VERIFY_X509_PARTIAL_CHAIN constant
+        (#231). urllib3 (which requests depends on) imports that constant via a
+        single ``from ssl import (...)`` statement, so its absence aborted the
+        whole import and silently disabled SSL, breaking every HTTPS request.
+        None of the other network tests exercise the requests/urllib3 HTTPS
+        path, so this guards against a recurrence.
+
+        Tries several hosts so a single slow/unreachable host doesn't flake CI
+        (matches the urllib external test and #224).
+        """
+        result = requests_sandbox.execute("""
+import requests
+
+urls = [
+    "https://httpbin.org/get",
+    "https://example.com",
+    "https://www.google.com",
+]
+
+for url in urls:
+    try:
+        response = requests.get(url, timeout=8)
+        if response.status_code == 200:
+            print(f"SUCCESS via {url}")
+            break
+    except Exception as e:
+        print(f"Failed {url}: {type(e).__name__}: {e}")
+else:
+    print("All URLs failed")
+""")
+        assert "SUCCESS" in result.stdout, f"Test failed: {result.stdout}"
+
 
 class TestHttpxLibrary:
     """Tests for the httpx library in the sandbox.
@@ -145,6 +180,35 @@ if response.status_code == 200:
         assert "SUCCESS" in result.stdout, (
             f"Test failed: {result.stdout}\nstderr: {result.stderr}"
         )
+
+    def test_httpx_get_https_external(self, httpx_sandbox):
+        """Test httpx.get() with HTTPS to an external service.
+
+        Parity with test_requests_get_https_external: exercises the ssl shim
+        through httpx's HTTP stack so a missing ssl constant or context attribute
+        can't silently break HTTPS. Tries several hosts to avoid CI flake (#224).
+        """
+        result = httpx_sandbox.execute("""
+import httpx
+
+urls = [
+    "https://httpbin.org/get",
+    "https://example.com",
+    "https://www.google.com",
+]
+
+for url in urls:
+    try:
+        response = httpx.get(url, timeout=8)
+        if response.status_code == 200:
+            print(f"SUCCESS via {url}")
+            break
+    except Exception as e:
+        print(f"Failed {url}: {type(e).__name__}: {e}")
+else:
+    print("All URLs failed")
+""")
+        assert "SUCCESS" in result.stdout, f"Test failed: {result.stdout}"
 
 
 class TestUrllibLibrary:

--- a/crates/eryx-python/tests/test_http_libraries.py
+++ b/crates/eryx-python/tests/test_http_libraries.py
@@ -181,35 +181,6 @@ if response.status_code == 200:
             f"Test failed: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_httpx_get_https_external(self, httpx_sandbox):
-        """Test httpx.get() with HTTPS to an external service.
-
-        Parity with test_requests_get_https_external: exercises the ssl shim
-        through httpx's HTTP stack so a missing ssl constant or context attribute
-        can't silently break HTTPS. Tries several hosts to avoid CI flake (#224).
-        """
-        result = httpx_sandbox.execute("""
-import httpx
-
-urls = [
-    "https://httpbin.org/get",
-    "https://example.com",
-    "https://www.google.com",
-]
-
-for url in urls:
-    try:
-        response = httpx.get(url, timeout=8)
-        if response.status_code == 200:
-            print(f"SUCCESS via {url}")
-            break
-    except Exception as e:
-        print(f"Failed {url}: {type(e).__name__}: {e}")
-else:
-    print("All URLs failed")
-""")
-        assert "SUCCESS" in result.stdout, f"Test failed: {result.stdout}"
-
 
 class TestUrllibLibrary:
     """Tests for urllib (standard library HTTP client).


### PR DESCRIPTION
## What

Adds an external-HTTPS regression test that drives `requests` over TLS in the sandbox: `TestRequestsLibrary::test_requests_get_https_external`.

## Why

PR #231 fixed a missing `ssl.VERIFY_X509_PARTIAL_CHAIN` constant that broke **all** `requests`/urllib3 HTTPS in the sandbox. It slipped through because **no test exercises `requests`/urllib3 over HTTPS** — of the 20+ network tests, the only external-HTTPS one (`test_urllib_https_external`) uses raw `urllib`, which never reaches urllib3's `from ssl import (...)` statement where that constant is required.

CI regenerates the runtime from source on any `crates/eryx-wasm-runtime/src/python.rs` change (the `wasm-runtime-v2-…` cache key in `ci.yml` hashes `crates/eryx-wasm-runtime/src/**`), so a test on this path actually catches future shim regressions. **Confirmed:** this test passes in CI against the fixed shim.

## How

Mirrors the existing `test_urllib_https_external` convention: a multi-host fallback (`httpbin.org` → `example.com` → `www.google.com`) with an 8s timeout, passing if any host returns 200 — resilient to CI network flake (same approach as #224). Reuses the existing `requests_sandbox` fixture.

## Note

An httpx parity test was drafted but **removed** — it surfaced a *separate, pre-existing* bug rather than the #231 regression: httpx/httpcore accesses `SSLSocket._sslobj`, which the stub ssl module doesn't implement, so httpx-over-HTTPS fails with `AttributeError: 'SSLSocket' object has no attribute '_sslobj'`. Tracked in #235; the httpx regression test should be added once that's fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)