### PR TITLE
fix(ci): let cargo-semver-checks build the embedded feature in release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,6 +56,21 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # release-plz runs cargo-semver-checks with its default (all-features)
+      # heuristic, which enables the `embedded` feature. That feature's build
+      # script requires a `runtime.cwasm`; without one it panics, the semver
+      # check silently no-ops, and API-breaking changes (e.g. new public struct
+      # fields) slip through as a patch bump instead of a minor one.
+      #
+      # For the semver check the cwasm is only embedded as bytes for rustdoc and
+      # is never deserialized or executed, so an empty placeholder is sufficient
+      # (identical to how the crate's own build.rs handles docs.rs builds). This
+      # avoids building the real WASM runtime here just to satisfy the check.
+      - name: Provide placeholder runtime.cwasm for cargo-semver-checks
+        run: |
+          : > "$RUNNER_TEMP/runtime.cwasm"
+          echo "ERYX_RUNTIME_CWASM=$RUNNER_TEMP/runtime.cwasm" >> "$GITHUB_ENV"
+
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
## Problem

release-plz's PR for v0.4.11 (#223) bumped every crate by a **patch**, reporting "✓ API compatible changes" — but #229 added two new `pub` fields (`result`, `result_error`) to `pub struct ExecuteResult`, which is all-public-field and **not** `#[non_exhaustive]`. Adding fields to such a struct is a breaking change (breaks downstream struct literals and exhaustive matches), so it should have been a **minor** bump (0.5.0 in 0.x terms).

### Root cause

release-plz runs `cargo-semver-checks` with its default **all-features** heuristic, which enables the `embedded` feature. That feature's `build.rs` requires a `runtime.cwasm`. The crates.io **baseline** (0.4.10) ships no such file, so the baseline build *panics*:

```
error: failed to run custom build command for `eryx v0.4.10`
  Pre-compiled runtime (runtime.cwasm) not found.
error: failed to build rustdoc for crate eryx v0.4.10
```

When the baseline can't be built, no breaking findings surface, release-plz falls back to conventional-commits only (`feat:` → patch in 0.x), and the PR is annotated "✓ API compatible changes". release-plz exposes no feature-scoping config for the semver check, so the fix is to make the all-features build succeed.

## Fix

For the semver check, `runtime.cwasm` is only embedded as bytes for rustdoc generation and is **never deserialized or executed** — exactly the situation the crate's own `build.rs` already handles for docs.rs with an empty placeholder. So this points `ERYX_RUNTIME_CWASM` at an empty file in the `release-plz-pr` job, satisfying both the baseline and current builds with zero extra build cost (no need to build the real WASM runtime or plumb artifacts across workflows).

## Verification (local, cargo-semver-checks 0.48.0)

With the empty-placeholder `ERYX_RUNTIME_CWASM` set, a clean all-features run builds both baseline and current and **correctly flags the break**:

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---
  field ExecuteResult.result        in crates/eryx/src/sandbox.rs:2323
  field ExecuteResult.result_error  in crates/eryx/src/sandbox.rs:2326
Summary semver requires new major version: 1 major and 0 minor checks failed
```

Without the env var, the baseline build panics (reproduced).

## Notes

- The `release-plz-pr` workflow only runs on push to `main`, so this PR's own CI won't exercise the change; it takes effect once merged.
- Companion PR marks `ExecuteResult` and other received/output structs `#[non_exhaustive]` so future additive fields are non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)