### PR TITLE
feat: mark result/output structs and error enums #[non_exhaustive]

### DIFF
--- a/crates/eryx-python/src/error.rs
+++ b/crates/eryx-python/src/error.rs
@@ -65,6 +65,9 @@ pub fn eryx_error_to_py(err: eryx::Error) -> PyErr {
             "execution ran out of fuel after {consumed} instructions (limit: {limit})"
         )),
         eryx::Error::Io(e) => PyRuntimeError::new_err(e.to_string()),
+        // `eryx::Error` is `#[non_exhaustive]`; map any future variants to a
+        // generic Eryx error rather than failing to compile.
+        other => EryxError::new_err(other.to_string()),
     }
 }
 

--- a/crates/eryx-runtime/src/linker.rs
+++ b/crates/eryx-runtime/src/linker.rs
@@ -55,6 +55,7 @@ impl NativeExtension {
 
 /// Metadata about a Python wheel.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct WheelInfo {
     /// Package name (e.g., "numpy")
     pub name: String,
@@ -150,6 +151,7 @@ pub fn parse_wheel(wheel_bytes: &[u8]) -> Result<WheelInfo, WheelParseError> {
 
 /// Errors that can occur when parsing a wheel.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum WheelParseError {
     /// The wheel is not a valid ZIP file.
     InvalidZip(String),
@@ -335,6 +337,7 @@ fn decompress_zstd(data: &[u8]) -> Result<Vec<u8>, LinkError> {
 
 /// Errors that can occur during linking.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum LinkError {
     /// Failed to add a base library.
     Library(String, String),

--- a/crates/eryx-runtime/src/preinit.rs
+++ b/crates/eryx-runtime/src/preinit.rs
@@ -779,6 +779,7 @@ async fn call_finalize_preinit(store: &mut Store<PreInitCtx>, instance: &Instanc
 
 /// Errors that can occur during pre-initialization.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum PreInitError {
     /// Failed to create wasmtime engine.
     Engine(String),

--- a/crates/eryx-vfs/src/error.rs
+++ b/crates/eryx-vfs/src/error.rs
@@ -7,6 +7,7 @@ pub type VfsResult<T> = Result<T, VfsError>;
 
 /// Errors that can occur during VFS operations.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VfsError {
     /// File or directory not found.
     #[error("not found: {0}")]

--- a/crates/eryx/src/cache.rs
+++ b/crates/eryx/src/cache.rs
@@ -61,6 +61,7 @@ use crate::wasm::{ExecutorState, SandboxPre};
 
 /// Error type for cache operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CacheError {
     /// I/O error when reading or writing cache files.
     #[error("I/O error: {0}")]

--- a/crates/eryx/src/callback.rs
+++ b/crates/eryx/src/callback.rs
@@ -286,6 +286,7 @@ impl<T: TypedCallback> Callback for T {
 
 /// Errors that can occur during callback execution.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CallbackError {
     /// The provided arguments don't match the expected schema.
     #[error("invalid arguments: {0}")]

--- a/crates/eryx/src/error.rs
+++ b/crates/eryx/src/error.rs
@@ -4,6 +4,7 @@ use crate::callback::CallbackError;
 
 /// The main error type for Eryx operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Error during sandbox initialization.
     #[error("initialization failed: {0}")]

--- a/crates/eryx/src/net.rs
+++ b/crates/eryx/src/net.rs
@@ -175,6 +175,7 @@ impl NetConfig {
 
 /// Errors that can occur during TCP operations.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum TcpError {
     /// Connection was refused by the remote host.
     ConnectionRefused,
@@ -214,6 +215,7 @@ impl std::error::Error for TcpError {}
 
 /// Errors that can occur during TLS operations.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum TlsError {
     /// Error from the underlying TCP layer.
     Tcp(TcpError),

--- a/crates/eryx/src/package.rs
+++ b/crates/eryx/src/package.rs
@@ -60,6 +60,7 @@ impl PackageFormat {
 
 /// An extracted package ready for use in a sandbox.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct ExtractedPackage {
     /// Package name (e.g., "numpy").
     pub name: String,
@@ -78,6 +79,7 @@ pub struct ExtractedPackage {
 
 /// A native extension (.so file) found in a package.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct NativeExtension {
     /// Relative path within the package (e.g., "numpy/core/_multiarray_umath.cpython-314-wasm32-wasi.so").
     /// This will be prefixed with the mount path when building the sandbox.

--- a/crates/eryx/src/pool.rs
+++ b/crates/eryx/src/pool.rs
@@ -120,6 +120,7 @@ impl Default for PoolConfig {
 
 /// Error type for pool operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PoolError {
     /// Pool has reached maximum capacity and no sandboxes are available.
     #[error("pool exhausted: all {0} sandboxes are in use")]
@@ -150,6 +151,7 @@ impl From<Error> for PoolError {
 
 /// Statistics about pool usage.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct PoolStats {
     /// Total number of sandboxes (in use + available).
     pub total: usize,

--- a/crates/eryx/src/sandbox.rs
+++ b/crates/eryx/src/sandbox.rs
@@ -2306,6 +2306,7 @@ impl SandboxBuilder<state::Has, state::Has> {
 
 /// Result of executing Python code in the sandbox.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ExecuteResult {
     /// Complete stdout output (also streamed via `OutputHandler` if configured).
     pub stdout: String,
@@ -2330,6 +2331,7 @@ pub struct ExecuteResult {
 
 /// Statistics about sandbox execution.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ExecuteStats {
     /// Total execution time.
     pub duration: Duration,

--- a/crates/eryx/src/schema.rs
+++ b/crates/eryx/src/schema.rs
@@ -178,6 +178,7 @@ impl Default for Schema {
 
 /// Errors that can occur when working with schemas.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SchemaError {
     /// The provided JSON value is not a valid JSON Schema.
     #[error("invalid schema: {0}")]

--- a/crates/eryx/src/session/executor.rs
+++ b/crates/eryx/src/session/executor.rs
@@ -92,6 +92,7 @@ pub struct PythonStateSnapshot {
 
 /// Metadata about a state snapshot.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SnapshotMetadata {
     /// Unix timestamp (milliseconds) when the snapshot was captured.
     pub timestamp_ms: u64,

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -150,6 +150,7 @@ pub enum NetRequest {
 
 /// Callback info for introspection (internal type to avoid conflicts with generated code).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct HostCallbackInfo {
     /// Unique name for this callback.
     pub name: String,


### PR DESCRIPTION
## Why

PR #229 added two new `pub` fields (`result`, `result_error`) to the public, all-public-field `ExecuteResult` struct in `crates/eryx/src/sandbox.rs`. Because that struct is `pub`, has all-public fields, and is **not** `#[non_exhaustive]`, downstream code can construct it with a struct literal and pattern-match it exhaustively. `cargo-semver-checks check-release --package eryx` correctly flags this as a breaking change (`constructible_struct_adds_field`) — so any future additive field on these types is a major-version bump.

This PR proactively marks the structs/enums that callers **receive** (and should never construct) as `#[non_exhaustive]`, so future additive field/variant changes are non-breaking. Marking them is itself a breaking change, which is expected and lands in the upcoming **0.5.0**.

## Structs marked `#[non_exhaustive]` (output / received)

| Type | Crate | Why |
|------|-------|-----|
| `ExecuteResult` | eryx | The trigger; execution result, all-pub fields |
| `ExecuteStats` | eryx | Execution statistics returned in `ExecuteResult` |
| `PoolStats` | eryx | Pool usage stats returned from `SandboxPool::stats()` |
| `SnapshotMetadata` | eryx | Snapshot metadata returned via `PythonStateSnapshot::metadata()` |
| `HostCallbackInfo` | eryx | Callback introspection info (received) |
| `ExtractedPackage` | eryx | Output of `ExtractedPackage::from_path` (already had a private field, so this mostly documents intent / guards future pub fields) |
| `package::NativeExtension` | eryx | Found inside `ExtractedPackage`; output-only |
| `linker::WheelInfo` | eryx-runtime | Output of `parse_wheel`; not consumed back as input |

`ExecutionOutput` (eryx) was already `#[non_exhaustive]`.

## Enums marked `#[non_exhaustive]` (callers match on them)

Error enums: future variant additions become non-breaking.

- eryx: `Error`, `PoolError`, `CallbackError`, `CacheError`, `SchemaError`, `TcpError`, `TlsError`
- eryx-vfs: `VfsError`
- eryx-runtime: `WheelParseError`, `LinkError`, `PreInitError`

The only exhaustive cross-crate match affected was `eryx-python`'s `eryx_error_to_py`, which now has a wildcard arm mapping future variants to a generic `EryxError`.

## Deliberately left alone (judgment calls)

These are **input / user-constructed / config / builder** types, or types that downstream code legitimately constructs — adding `#[non_exhaustive]` would break users:

- **Builders / config the user constructs:** `SandboxBuilder`, `ResourceLimits`, `NetConfig`, `PoolConfig`, `SecretConfig`, `CacheKey`, `VfsConfig`, `VolumeMount`.
- **Input enums:** `CpuFeatureLevel` (passed into `precompile_with_options`), `PackageFormat` (passed into `with_package_bytes`), `FileScrubPolicy` / `OutputScrubPolicy` (scrubbing config).
- **`linker::NativeExtension`** — input to `link_with_extensions` / `compute_cache_key` / `pre_initialize`; users construct it (it even has a `::new()` constructor).
- **VFS `Metadata` / `DirEntry`** — produced by downstream `VfsStorage` trait implementations, so they are construct-side for implementors.
- **`TraceEvent` / `TraceEventKind`** — although these are technically receive-side (delivered to `TraceHandler::on_trace`), downstream code (including `eryx-server`'s own tests) constructs them via struct literals to drive a `TraceHandler`, and there is no public constructor. Marking them `#[non_exhaustive]` would break those callers with no migration path, so they're left as-is.
- **`NetRequest`** (eryx) — internal host plumbing carrying `oneshot::Sender` channels; not a user-facing output.

## Breaking change note

This is a breaking change (adding `#[non_exhaustive]`), intended for 0.5.0. Crate versions are untouched — release-plz handles versioning.

## Testing

- `cargo build -p eryx -p eryx-runtime -p eryx-vfs` — clean
- `cargo clippy -p eryx -p eryx-runtime -p eryx-vfs --all-targets -- -D warnings` — clean
- `cargo test --lib` for the three published crates — all pass
- `eryx-python` enables the `embedded` feature, which requires a pre-compiled `runtime.cwasm` not present in a fresh worktree; that build is left to CI. The only change there is a one-line wildcard match arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)