### PR TITLE
fix(server): surface captured output on the execution error path

### DIFF
--- a/crates/eryx-python/src/error.rs
+++ b/crates/eryx-python/src/error.rs
@@ -50,6 +50,9 @@ pub fn eryx_error_to_py(err: eryx::Error) -> PyErr {
         eryx::Error::WasmEngine(msg) => InitializationError::new_err(msg),
         eryx::Error::WasmComponent(e) => InitializationError::new_err(e.to_string()),
         eryx::Error::Execution(msg) => ExecutionError::new_err(msg),
+        // A script raising an uncaught exception is also an execution error from
+        // the Python caller's perspective; keep it mapped to ExecutionError.
+        eryx::Error::PythonException(msg) => ExecutionError::new_err(msg),
         eryx::Error::Callback(e) => ExecutionError::new_err(e.to_string()),
         eryx::Error::ResourceLimit(msg) => ResourceLimitError::new_err(msg),
         eryx::Error::Timeout(duration) => {

--- a/crates/eryx-server/proto/eryx/v1/eryx.proto
+++ b/crates/eryx-server/proto/eryx/v1/eryx.proto
@@ -248,7 +248,11 @@ message ExecuteResult {
   // Complete stderr output.
   string stderr = 3;
 
-  // Error message if execution failed.
+  // Human-readable message for a *sandbox* failure (timeout, fuel exhaustion,
+  // WASM trap, invalid input, etc.). Empty when execution succeeded AND empty
+  // for an uncaught Python exception — in that case the traceback is in
+  // `stderr` (as CPython would print it) and `failure_kind` is
+  // FAILURE_KIND_SCRIPT_EXCEPTION. Use `failure_kind` to branch, not this string.
   string error = 4;
 
   // Execution statistics.
@@ -266,6 +270,32 @@ message ExecuteResult {
   // Why result capture failed (e.g. the value was not JSON-serializable), or
   // empty when capture succeeded or no result variable was set.
   string result_error = 8;
+
+  // Why execution failed. FAILURE_KIND_UNSPECIFIED when success is true.
+  // Distinguishes a script-level failure (an uncaught Python exception, with
+  // its traceback in `stderr`) from sandbox-level failures (timeout, fuel
+  // exhaustion, traps, invalid input), so callers can branch without parsing
+  // the `error` string.
+  FailureKind failure_kind = 9;
+}
+
+// Why an execution failed, when success is false.
+enum FailureKind {
+  // Execution succeeded; no failure.
+  FAILURE_KIND_UNSPECIFIED = 0;
+  // The script raised an uncaught Python exception. The traceback is in
+  // `stderr` and `error` is empty.
+  FAILURE_KIND_SCRIPT_EXCEPTION = 1;
+  // Execution exceeded the configured wall-clock timeout.
+  FAILURE_KIND_TIMEOUT = 2;
+  // Execution exceeded the configured fuel (instruction) limit.
+  FAILURE_KIND_FUEL_EXHAUSTED = 3;
+  // A sandbox/infrastructure failure: WASM trap, invalid input (e.g. NUL bytes
+  // in the code), session creation failure, or an internal runtime error.
+  // Details are in `error`.
+  FAILURE_KIND_SANDBOX_ERROR = 4;
+  // Execution was cancelled before completing (e.g. the client disconnected).
+  FAILURE_KIND_CANCELLED = 5;
 }
 
 // A trace event emitted during execution.

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -8,7 +8,7 @@ use dashmap::DashMap;
 use eryx::callback_handler::{run_callback_handler, run_net_handler};
 use eryx::vfs::{ArcStorage, InMemoryStorage, VfsStorage};
 use eryx::{
-    Callback, CallbackRequest, ConnectionManager, NetConfig, NetRequest, OutputRequest,
+    Callback, CallbackRequest, ConnectionManager, Error, NetConfig, NetRequest, OutputRequest,
     PythonStateSnapshot, ResourceLimits, SandboxPool, SecretConfig, SessionExecutor, TraceRequest,
     VfsConfig, generate_placeholder, scrub_placeholders,
 };
@@ -23,8 +23,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::callbacks::{self, CallbackResult, PendingCallbacks};
 use crate::proto::eryx::v1::{
-    ClientMessage, ExecuteResult, ExecuteStats, FileKind, ServerMessage, SupportingFile,
-    callback_response, client_message, server_message,
+    ClientMessage, ExecuteResult, ExecuteStats, FailureKind, FileKind, ServerMessage,
+    SupportingFile, callback_response, client_message, server_message,
 };
 
 /// Adapts tonic's [`MetadataMap`] to OpenTelemetry's [`Extractor`] trait,
@@ -375,6 +375,7 @@ impl crate::proto::eryx::v1::eryx_server::Eryx for EryxService {
                             state_snapshot: Vec::new(),
                             result: String::new(),
                             result_error: String::new(),
+                            failure_kind: FailureKind::Cancelled as i32,
                         }
                     }
                 };
@@ -551,6 +552,7 @@ async fn execute_with_session(
                 return ExecuteResult {
                     success: false,
                     error: format!("session creation failed: {e}"),
+                    failure_kind: FailureKind::SandboxError as i32,
                     ..Default::default()
                 };
             }
@@ -582,6 +584,7 @@ async fn execute_with_session(
                 return ExecuteResult {
                     success: false,
                     error: format!("session creation failed: {e}"),
+                    failure_kind: FailureKind::SandboxError as i32,
                     ..Default::default()
                 };
             }
@@ -878,12 +881,15 @@ async fn execute_with_session(
                 state_snapshot: snapshot_bytes,
                 result,
                 result_error,
+                failure_kind: FailureKind::Unspecified as i32,
             }
         }
         Err(e) => {
+            let failure_kind = classify_failure(&e);
             tracing::warn!(
                 success = false,
                 error = %e,
+                failure_kind = ?failure_kind,
                 "session execution completed"
             );
             metrics::counter!("eryx_executions_total", "status" => "error").increment(1);
@@ -902,18 +908,42 @@ async fn execute_with_session(
             } else {
                 streamed_stderr
             };
+            // For a script exception the traceback is already in `stderr`
+            // (CPython-style); `error` is reserved for sandbox failures, so leave
+            // it empty and let callers branch on `failure_kind`.
+            let error = if failure_kind == FailureKind::ScriptException {
+                String::new()
+            } else {
+                e.to_string()
+            };
             ExecuteResult {
                 success: false,
                 stdout,
                 stderr,
-                error: e.to_string(),
+                error,
                 stats: None,
                 // Still return the snapshot — the Go service decides whether to keep it.
                 state_snapshot: snapshot_bytes,
                 result: String::new(),
                 result_error: String::new(),
+                failure_kind: failure_kind as i32,
             }
         }
+    }
+}
+
+/// Classify a library [`Error`] into the proto [`FailureKind`].
+///
+/// [`Error::PythonException`] is a *script* failure — its traceback is surfaced
+/// in `stderr` — so it maps to [`FailureKind::ScriptException`]. Everything else
+/// is a sandbox-level failure whose message belongs in the `error` field.
+fn classify_failure(error: &Error) -> FailureKind {
+    match error {
+        Error::PythonException(_) => FailureKind::ScriptException,
+        Error::Timeout(_) => FailureKind::Timeout,
+        Error::FuelExhausted { .. } => FailureKind::FuelExhausted,
+        Error::Cancelled => FailureKind::Cancelled,
+        _ => FailureKind::SandboxError,
     }
 }
 

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -910,11 +910,15 @@ async fn execute_with_session(
             };
             // For a script exception the traceback is already in `stderr`
             // (CPython-style); `error` is reserved for sandbox failures, so leave
-            // it empty and let callers branch on `failure_kind`.
+            // it empty and let callers branch on `failure_kind`. For machinery
+            // failures, scrub the message as defense-in-depth in case a future
+            // error string ever interpolates user-derived input. (Secrets reach
+            // Python only as placeholders, so this scrubs placeholders, never
+            // real values; it is a no-op when no secrets are configured.)
             let error = if failure_kind == FailureKind::ScriptException {
                 String::new()
             } else {
-                e.to_string()
+                scrub_placeholders(&e.to_string(), &params.secrets)
             };
             ExecuteResult {
                 success: false,

--- a/crates/eryx-server/src/service.rs
+++ b/crates/eryx-server/src/service.rs
@@ -699,12 +699,20 @@ async fn execute_with_session(
     } else {
         None
     };
-    tokio::spawn(async move {
+    // Accumulate the raw (pre-scrub) streamed output so the final ExecuteResult
+    // can carry it. The error path otherwise loses captured output entirely
+    // because no ExecutionOutput is produced; accumulating here lets the final
+    // stdout/stderr fields match what was streamed (and the success path).
+    let output_accumulator = tokio::spawn(async move {
         use crate::proto::eryx::v1::{OutputEvent, OutputStream};
+        let mut stdout_buf = String::new();
+        let mut stderr_buf = String::new();
         while let Some(req) = output_rx.recv().await {
             let stream = if req.stream == 0 {
+                stdout_buf.push_str(&req.data);
                 OutputStream::Stdout
             } else {
+                stderr_buf.push_str(&req.data);
                 OutputStream::Stderr
             };
             let data = if let Some(ref secrets) = output_secrets {
@@ -730,6 +738,7 @@ async fn execute_with_session(
                 break;
             }
         }
+        (stdout_buf, stderr_buf)
     });
 
     // Spawn network handler if networking is enabled (mirrors Sandbox::execute pattern).
@@ -780,6 +789,11 @@ async fn execute_with_session(
 
     // Wait for callback handler to finish.
     let callback_invocations = callback_handler.await.unwrap_or(0);
+
+    // The output channel sender is dropped once execution completes, so the
+    // accumulator task has now (or will shortly) finish draining. Its captured
+    // stdout/stderr are used to populate the error-path result below.
+    let (streamed_stdout, streamed_stderr) = output_accumulator.await.unwrap_or_default();
 
     // Snapshot state after execution (only when persistence is requested).
     let snapshot_bytes = if params.state.is_some() {
@@ -874,10 +888,24 @@ async fn execute_with_session(
             );
             metrics::counter!("eryx_executions_total", "status" => "error").increment(1);
             metrics::histogram!("eryx_execution_duration_seconds").record(duration.as_secs_f64());
+            // Surface output captured before the failure (e.g. an uncaught
+            // exception's traceback, which Python writes to stderr) so the
+            // stdout/stderr fields match what was streamed and the success path.
+            // Scrub the whole buffer, consistent with the Ok arm.
+            let stdout = if params.scrub_stdout {
+                scrub_placeholders(&streamed_stdout, &params.secrets)
+            } else {
+                streamed_stdout
+            };
+            let stderr = if params.scrub_stderr {
+                scrub_placeholders(&streamed_stderr, &params.secrets)
+            } else {
+                streamed_stderr
+            };
             ExecuteResult {
                 success: false,
-                stdout: String::new(),
-                stderr: String::new(),
+                stdout,
+                stderr,
                 error: e.to_string(),
                 stats: None,
                 // Still return the snapshot — the Go service decides whether to keep it.

--- a/crates/eryx-server/tests/grpc_e2e.rs
+++ b/crates/eryx-server/tests/grpc_e2e.rs
@@ -314,6 +314,103 @@ async fn execute_null_bytes_is_sandbox_failure() {
     assert!(got_result, "never received ExecuteResult");
 }
 
+/// A secret surfaced via an uncaught exception's traceback must not leak. Two
+/// guarantees compound here: Python only ever sees a random *placeholder* (never
+/// the real value), and stderr scrubbing replaces that placeholder with
+/// `[REDACTED]`. Verified across the streamed events, the `stderr` field, and
+/// the (empty) `error` field.
+#[tokio::test]
+async fn execute_secret_in_uncaught_exception_is_scrubbed() {
+    use eryx_server::proto::eryx::v1::{FailureKind, OutputStream, SecretConfig};
+
+    const REAL_SECRET: &str = "s3cr3t-value-do-not-leak-42";
+
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                code: "import os\nraise Exception(os.environ['MY_SECRET'])".to_string(),
+                secrets: vec![SecretConfig {
+                    name: "MY_SECRET".to_string(),
+                    value: REAL_SECRET.to_string(),
+                    allowed_hosts: vec![],
+                }],
+                callbacks: vec![],
+                resource_limits: Some(ResourceLimits {
+                    execution_timeout_ms: 30_000,
+                    ..Default::default()
+                }),
+                enable_tracing: false,
+                persist_state: false,
+                state_snapshot: vec![],
+                files: vec![],
+                network_config: None,
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    let mut stderr_events: Vec<String> = Vec::new();
+    while let Some(msg) = stream.message().await.unwrap() {
+        match msg.message {
+            Some(server_message::Message::OutputEvent(event)) => {
+                if event.stream == OutputStream::Stderr as i32 {
+                    stderr_events.push(event.data);
+                }
+            }
+            Some(server_message::Message::ExecuteResult(result)) => {
+                assert!(!result.success);
+                assert_eq!(result.failure_kind, FailureKind::ScriptException as i32);
+                // The real secret never reaches Python, so it cannot appear
+                // anywhere, and the placeholder must be scrubbed from stderr.
+                assert!(
+                    !result.stderr.contains(REAL_SECRET),
+                    "real secret leaked into stderr: {:?}",
+                    result.stderr
+                );
+                assert!(
+                    !result.stderr.contains("ERYX_SECRET_PLACEHOLDER_"),
+                    "unscrubbed placeholder leaked into stderr: {:?}",
+                    result.stderr
+                );
+                assert!(
+                    result.stderr.contains("[REDACTED]"),
+                    "expected the placeholder to be redacted in the traceback: {:?}",
+                    result.stderr
+                );
+                // `error` is empty for a script exception — nothing to leak there.
+                assert!(result.error.is_empty());
+                got_result = true;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(got_result, "never received ExecuteResult");
+    // The real secret can never appear in the live stream either — Python only
+    // ever holds the placeholder. (We don't assert placeholder-absence on the
+    // raw stream: per-chunk scrubbing can't redact a placeholder split across
+    // two writes. The final `stderr` field, scrubbed whole, is the guarantee.)
+    let streamed = stderr_events.concat();
+    assert!(
+        !streamed.contains(REAL_SECRET),
+        "real secret leaked into streamed stderr events: {:?}",
+        stderr_events
+    );
+}
+
 #[tokio::test]
 async fn execute_with_echo_callback() {
     let channel = start_server().await;

--- a/crates/eryx-server/tests/grpc_e2e.rs
+++ b/crates/eryx-server/tests/grpc_e2e.rs
@@ -104,16 +104,14 @@ async fn execute_simple_print() {
 }
 
 /// An uncaught exception over gRPC. The traceback (which Python writes to
-/// stderr) is surfaced consistently in three places:
+/// stderr) is surfaced as CPython would — over stderr, not as a sandbox error:
 ///   - streamed live as STDERR `OutputEvent`s while the code runs,
 ///   - in the final `ExecuteResult.stderr` field, and
-///   - in `ExecuteResult.error`, with `success = false`.
-///
-/// The `stderr` field used to be empty on the error path; it now matches the
-/// stream and the success path.
+///   - classified via `failure_kind = SCRIPT_EXCEPTION`, with `error` left empty
+///     (it is reserved for sandbox-level failures) and `success = false`.
 #[tokio::test]
 async fn execute_uncaught_exception_returns_error_not_stderr() {
-    use eryx_server::proto::eryx::v1::OutputStream;
+    use eryx_server::proto::eryx::v1::{FailureKind, OutputStream};
 
     let channel = start_server().await;
     let mut client = EryxClient::new(channel);
@@ -162,13 +160,19 @@ async fn execute_uncaught_exception_returns_error_not_stderr() {
                     !result.success,
                     "uncaught exception should report success=false"
                 );
-                // The traceback is surfaced through the error field...
+                // Classified as a script exception, not a sandbox failure.
+                assert_eq!(
+                    result.failure_kind,
+                    FailureKind::ScriptException as i32,
+                    "uncaught exception should be FAILURE_KIND_SCRIPT_EXCEPTION"
+                );
+                // `error` is reserved for sandbox failures, so it stays empty.
                 assert!(
-                    result.error.contains("Traceback") && result.error.contains("Exception"),
-                    "error should carry the traceback, got: {:?}",
+                    result.error.is_empty(),
+                    "error should be empty for a script exception, got: {:?}",
                     result.error
                 );
-                // ...and also through the stderr field (matching the stream).
+                // The traceback is surfaced through stderr (matching the stream).
                 assert!(
                     result.stderr.contains("Traceback") && result.stderr.contains("Exception"),
                     "stderr field should carry the traceback, got: {:?}",
@@ -194,6 +198,120 @@ async fn execute_uncaught_exception_returns_error_not_stderr() {
         "expected the traceback to be streamed as STDERR events, got: {:?}",
         stderr_events
     );
+}
+
+/// A wall-clock timeout is a sandbox failure, not a script failure: it is
+/// classified `FAILURE_KIND_TIMEOUT` with a populated `error` (the limit isn't
+/// something CPython surfaces, so it belongs in `error`, not stderr).
+#[tokio::test]
+async fn execute_timeout_is_sandbox_failure() {
+    use eryx_server::proto::eryx::v1::FailureKind;
+
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                // Busy loop that never returns before the tiny timeout.
+                code: "while True:\n    pass".to_string(),
+                callbacks: vec![],
+                resource_limits: Some(ResourceLimits {
+                    execution_timeout_ms: 200,
+                    ..Default::default()
+                }),
+                enable_tracing: false,
+                persist_state: false,
+                state_snapshot: vec![],
+                files: vec![],
+                network_config: None,
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    while let Some(msg) = stream.message().await.unwrap() {
+        if let Some(server_message::Message::ExecuteResult(result)) = msg.message {
+            assert!(!result.success, "timeout should report success=false");
+            assert_eq!(
+                result.failure_kind,
+                FailureKind::Timeout as i32,
+                "timeout should be FAILURE_KIND_TIMEOUT"
+            );
+            assert!(
+                !result.error.is_empty(),
+                "a sandbox failure should populate the error field"
+            );
+            got_result = true;
+        }
+    }
+    assert!(got_result, "never received ExecuteResult");
+}
+
+/// NUL bytes in the code are rejected host-side before reaching the guest, and
+/// classified as a sandbox/input failure rather than a script exception.
+#[tokio::test]
+async fn execute_null_bytes_is_sandbox_failure() {
+    use eryx_server::proto::eryx::v1::FailureKind;
+
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                code: "x = 1\0y = 2".to_string(),
+                callbacks: vec![],
+                resource_limits: Some(ResourceLimits {
+                    execution_timeout_ms: 30_000,
+                    ..Default::default()
+                }),
+                enable_tracing: false,
+                persist_state: false,
+                state_snapshot: vec![],
+                files: vec![],
+                network_config: None,
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    while let Some(msg) = stream.message().await.unwrap() {
+        if let Some(server_message::Message::ExecuteResult(result)) = msg.message {
+            assert!(!result.success, "null bytes should report success=false");
+            assert_eq!(
+                result.failure_kind,
+                FailureKind::SandboxError as i32,
+                "null bytes should be FAILURE_KIND_SANDBOX_ERROR, not a script exception"
+            );
+            assert!(
+                !result.error.is_empty(),
+                "a sandbox failure should populate the error field"
+            );
+            got_result = true;
+        }
+    }
+    assert!(got_result, "never received ExecuteResult");
 }
 
 #[tokio::test]

--- a/crates/eryx-server/tests/grpc_e2e.rs
+++ b/crates/eryx-server/tests/grpc_e2e.rs
@@ -103,6 +103,99 @@ async fn execute_simple_print() {
     assert!(got_result, "never received ExecuteResult");
 }
 
+/// An uncaught exception over gRPC. The traceback (which Python writes to
+/// stderr) is surfaced consistently in three places:
+///   - streamed live as STDERR `OutputEvent`s while the code runs,
+///   - in the final `ExecuteResult.stderr` field, and
+///   - in `ExecuteResult.error`, with `success = false`.
+///
+/// The `stderr` field used to be empty on the error path; it now matches the
+/// stream and the success path.
+#[tokio::test]
+async fn execute_uncaught_exception_returns_error_not_stderr() {
+    use eryx_server::proto::eryx::v1::OutputStream;
+
+    let channel = start_server().await;
+    let mut client = EryxClient::new(channel);
+
+    let (tx, rx) = mpsc::channel(16);
+    tx.send(ClientMessage {
+        message: Some(client_message::Message::ExecuteRequest(Box::new(
+            ExecuteRequest {
+                // Print to stdout first, then raise: both captured streams must
+                // survive onto the final result.
+                code: "print('before the boom')\nraise Exception()".to_string(),
+                callbacks: vec![],
+                resource_limits: Some(ResourceLimits {
+                    execution_timeout_ms: 30_000,
+                    ..Default::default()
+                }),
+                enable_tracing: false,
+                persist_state: false,
+                state_snapshot: vec![],
+                files: vec![],
+                network_config: None,
+                ..Default::default()
+            },
+        ))),
+    })
+    .await
+    .unwrap();
+
+    let mut stream = client
+        .execute(ReceiverStream::new(rx))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut got_result = false;
+    let mut stderr_events: Vec<String> = Vec::new();
+    while let Some(msg) = stream.message().await.unwrap() {
+        match msg.message {
+            Some(server_message::Message::OutputEvent(event)) => {
+                if event.stream == OutputStream::Stderr as i32 {
+                    stderr_events.push(event.data);
+                }
+            }
+            Some(server_message::Message::ExecuteResult(result)) => {
+                assert!(
+                    !result.success,
+                    "uncaught exception should report success=false"
+                );
+                // The traceback is surfaced through the error field...
+                assert!(
+                    result.error.contains("Traceback") && result.error.contains("Exception"),
+                    "error should carry the traceback, got: {:?}",
+                    result.error
+                );
+                // ...and also through the stderr field (matching the stream).
+                assert!(
+                    result.stderr.contains("Traceback") && result.stderr.contains("Exception"),
+                    "stderr field should carry the traceback, got: {:?}",
+                    result.stderr
+                );
+                // stdout produced before the exception is preserved too.
+                assert!(
+                    result.stdout.contains("before the boom"),
+                    "stdout field should carry pre-exception output, got: {:?}",
+                    result.stdout
+                );
+                got_result = true;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(got_result, "never received ExecuteResult");
+    // The traceback IS delivered live as STDERR output events during execution.
+    let streamed = stderr_events.concat();
+    assert!(
+        streamed.contains("Traceback") && streamed.contains("Exception"),
+        "expected the traceback to be streamed as STDERR events, got: {:?}",
+        stderr_events
+    );
+}
+
 #[tokio::test]
 async fn execute_with_echo_callback() {
     let channel = start_server().await;

--- a/crates/eryx/src/error.rs
+++ b/crates/eryx/src/error.rs
@@ -18,9 +18,19 @@ pub enum Error {
     #[error("wasm component error: {0}")]
     WasmComponent(#[from] wasmtime::Error),
 
-    /// Error during Python execution.
+    /// Error during Python execution machinery (e.g. a WASM trap, the store or
+    /// bindings being unavailable, or invalid input). This is a *sandbox* failure
+    /// — the runtime could not faithfully execute the script. An uncaught
+    /// exception raised *by* the script is [`Error::PythonException`] instead.
     #[error("execution failed: {0}")]
     Execution(String),
+
+    /// The script raised an uncaught Python exception. The contained string is
+    /// the traceback exactly as CPython would have written it to stderr. This is
+    /// a *script* failure, not a sandbox failure: the runtime ran the code
+    /// faithfully and the code itself errored.
+    #[error("{0}")]
+    PythonException(String),
 
     /// A callback error occurred during execution.
     #[error("callback error: {0}")]
@@ -74,4 +84,20 @@ impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Self {
         Self::Serialization(err.to_string())
     }
+}
+
+/// Reject user code the guest cannot run, before it reaches the WASM boundary.
+///
+/// Currently this rejects embedded NUL bytes: the code is handed to the guest
+/// as a C string, so a NUL would be caught there and surface as an opaque guest
+/// error. Validating host-side keeps it classified as a sandbox/input failure
+/// ([`Error::Execution`]) rather than being mistaken for an uncaught Python
+/// exception ([`Error::PythonException`]).
+pub(crate) fn validate_user_code(code: &str) -> Result<(), Error> {
+    if code.contains('\0') {
+        return Err(Error::Execution(
+            "code contains NUL bytes, which cannot be executed".to_string(),
+        ));
+    }
+    Ok(())
 }

--- a/crates/eryx/src/session/executor.rs
+++ b/crates/eryx/src/session/executor.rs
@@ -955,6 +955,8 @@ impl SessionExecutor {
         output_tx: Option<mpsc::UnboundedSender<crate::wasm::OutputRequest>>,
         per_execute_fuel_limit: Option<u64>,
     ) -> Result<ExecutionOutput, Error> {
+        crate::error::validate_user_code(code)?;
+
         let start = Instant::now();
 
         // Take ownership of store and bindings for async execution
@@ -1111,10 +1113,12 @@ impl SessionExecutor {
             }
         })?;
         // wasmtime_result is Result<Result<ExecuteOutput, String>, wasmtime::Error>
-        // The outer Result is from wasmtime, the inner is the WIT-generated result
+        // The outer Result is from wasmtime, the inner is the WIT-generated result.
+        // The inner Err is the guest's logical execution error — for real input
+        // that is always an uncaught Python exception (its traceback).
         let wit_output = wasmtime_result
             .map_err(|e| Error::Execution(format!("WASM execution error: {e:?}")))?
-            .map_err(Error::Execution)?;
+            .map_err(Error::PythonException)?;
 
         let duration = start.elapsed();
 

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -1942,6 +1942,8 @@ impl PythonExecutor {
         #[cfg(feature = "vfs")] vfs_storage: Option<eryx_vfs::ArcStorage>,
         #[cfg(feature = "vfs")] volumes: Vec<crate::session::VolumeMount>,
     ) -> std::result::Result<ExecutionOutput, Error> {
+        crate::error::validate_user_code(code)?;
+
         // Build callback info for introspection
         let callback_infos: Vec<HostCallbackInfo> = callbacks
             .iter()
@@ -2267,9 +2269,11 @@ impl PythonExecutor {
         // wasmtime_result is Result<Result<ExecuteOutput, String>, wasmtime::Error> from the WIT layer
         // The outer Result is from wasmtime, the inner is the WIT-generated result
         // where ExecuteOutput is the WIT-generated record with stdout and stderr
+        // The inner WIT Err is the guest's logical execution error — for real
+        // input that is always an uncaught Python exception (its traceback).
         let wit_output = wasmtime_result
             .map_err(|e| Error::Execution(format!("WASM execution error: {e:?}")))?
-            .map_err(Error::Execution)?;
+            .map_err(Error::PythonException)?;
 
         // Get peak memory from the store before it's dropped
         let peak_memory_bytes = store.data().memory_tracker.peak_memory_bytes();

--- a/crates/eryx/tests/error_handling.rs
+++ b/crates/eryx/tests/error_handling.rs
@@ -288,17 +288,15 @@ async fn test_python_value_error() {
     );
 }
 
-/// An uncaught exception surfaces the full Python traceback.
+/// An uncaught exception surfaces the full Python traceback as a
+/// [`eryx::Error::PythonException`] — a *script* failure, distinct from
+/// sandbox failures.
 ///
 /// Regression guard for a user report that `raise Exception()` "does not return
-/// anything". It does: an uncaught exception is returned as an `Err` whose
-/// message is the full traceback (captured from the redirected `sys.stderr`),
-/// including the exception *type* even when no message is supplied.
-///
-/// Note the channel: the traceback comes back through the error return, NOT in
-/// the `stderr` field of a successful `ExecutionOutput` (on the error path there
-/// is no output struct). The gRPC layer mirrors this — it puts the traceback in
-/// `ExecuteResult.error` and leaves `stderr` empty.
+/// anything". It does: the returned `Err` carries the full traceback (captured
+/// from the redirected `sys.stderr`), including the exception *type* even when no
+/// message is supplied. The dedicated variant lets callers tell "the script
+/// raised" apart from "the sandbox failed" without parsing the message.
 #[tokio::test]
 async fn test_python_uncaught_exception_returns_traceback() {
     let mut session = create_session().await;
@@ -309,6 +307,10 @@ async fn test_python_uncaught_exception_returns_traceback() {
         .run()
         .await
         .expect_err("raise Exception() should be an error");
+    assert!(
+        matches!(bare, eryx::Error::PythonException(_)),
+        "a raise should be a PythonException, got: {bare:?}"
+    );
     let bare = bare.to_string();
     assert!(
         !bare.trim().is_empty(),
@@ -325,11 +327,36 @@ async fn test_python_uncaught_exception_returns_traceback() {
         .execute(r#"raise ValueError("boom")"#)
         .run()
         .await
-        .expect_err(r#"raise ValueError("boom") should be an error"#)
-        .to_string();
+        .expect_err(r#"raise ValueError("boom") should be an error"#);
+    assert!(
+        matches!(with_msg, eryx::Error::PythonException(_)),
+        "a raise should be a PythonException, got: {with_msg:?}"
+    );
+    let with_msg = with_msg.to_string();
     assert!(
         with_msg.contains("ValueError") && with_msg.contains("boom"),
         "expected 'ValueError: boom' in traceback, got: {with_msg:?}"
+    );
+}
+
+/// NUL bytes in the code are rejected host-side as a sandbox/input failure
+/// ([`eryx::Error::Execution`]), NOT mistaken for a script exception.
+#[tokio::test]
+async fn test_null_bytes_in_code_is_not_python_exception() {
+    let mut session = create_session().await;
+
+    let err = session
+        .execute("x = 1\0y = 2")
+        .run()
+        .await
+        .expect_err("code with NUL bytes should be rejected");
+    assert!(
+        matches!(err, eryx::Error::Execution(_)),
+        "NUL bytes should be a sandbox Execution error, not PythonException, got: {err:?}"
+    );
+    assert!(
+        !matches!(err, eryx::Error::PythonException(_)),
+        "NUL bytes must not be classified as a script exception"
     );
 }
 

--- a/crates/eryx/tests/error_handling.rs
+++ b/crates/eryx/tests/error_handling.rs
@@ -288,6 +288,51 @@ async fn test_python_value_error() {
     );
 }
 
+/// An uncaught exception surfaces the full Python traceback.
+///
+/// Regression guard for a user report that `raise Exception()` "does not return
+/// anything". It does: an uncaught exception is returned as an `Err` whose
+/// message is the full traceback (captured from the redirected `sys.stderr`),
+/// including the exception *type* even when no message is supplied.
+///
+/// Note the channel: the traceback comes back through the error return, NOT in
+/// the `stderr` field of a successful `ExecutionOutput` (on the error path there
+/// is no output struct). The gRPC layer mirrors this — it puts the traceback in
+/// `ExecuteResult.error` and leaves `stderr` empty.
+#[tokio::test]
+async fn test_python_uncaught_exception_returns_traceback() {
+    let mut session = create_session().await;
+
+    // Bare exception with no message: the type name must still appear.
+    let bare = session
+        .execute("raise Exception()")
+        .run()
+        .await
+        .expect_err("raise Exception() should be an error");
+    let bare = bare.to_string();
+    assert!(
+        !bare.trim().is_empty(),
+        "bare Exception() produced an empty error: {bare:?}"
+    );
+    assert!(
+        bare.contains("Traceback") && bare.contains("Exception"),
+        "expected a traceback naming the exception type, got: {bare:?}"
+    );
+
+    // Message-bearing exception: both type and message appear.
+    let mut session = create_session().await;
+    let with_msg = session
+        .execute(r#"raise ValueError("boom")"#)
+        .run()
+        .await
+        .expect_err(r#"raise ValueError("boom") should be an error"#)
+        .to_string();
+    assert!(
+        with_msg.contains("ValueError") && with_msg.contains("boom"),
+        "expected 'ValueError: boom' in traceback, got: {with_msg:?}"
+    );
+}
+
 // =============================================================================
 // Edge Case Tests
 // =============================================================================

--- a/crates/eryx/tests/execution_cancellation.rs
+++ b/crates/eryx/tests/execution_cancellation.rs
@@ -294,7 +294,7 @@ async fn test_python_error_not_confused_with_cancellation() {
     assert!(result.is_err(), "Should fail with Python error");
     match result {
         Err(Error::Cancelled) => panic!("Should not be Cancelled error"),
-        Err(Error::Execution(msg)) => {
+        Err(Error::PythonException(msg)) => {
             assert!(
                 msg.contains("ValueError") || msg.contains("test error"),
                 "Error should mention ValueError: {}",
@@ -316,7 +316,7 @@ async fn test_syntax_error_not_confused_with_cancellation() {
     assert!(result.is_err(), "Should fail with syntax error");
     match result {
         Err(Error::Cancelled) => panic!("Should not be Cancelled error"),
-        Err(Error::Execution(_)) => {} // Expected
+        Err(Error::PythonException(_)) => {} // Expected: syntax error raises in-guest
         Err(e) => panic!("Unexpected error type: {:?}", e),
         Ok(_) => panic!("Expected error, got success"),
     }


### PR DESCRIPTION
## Summary

Started from a user report that `raise Exception()` "returns nothing over stderr." Fixing that surfaced a deeper design issue, addressed in two commits.

### Commit 1 — `fix(server)`: surface captured output on the error path
The traceback was streamed live over STDERR and present in `error`, but the final `ExecuteResult.stderr` field was hard-coded empty on the error path. Now the gRPC output accumulator populates `stdout`/`stderr` on the error path too, so the field matches the stream and the success path. Output produced before a failure is preserved.

### Commit 2 — `feat`: distinguish script exceptions from sandbox failures
`success=false` + `error` conflated two very different things, and the traceback was duplicated across `stderr` and `error`. Adopted the rule: **"anything CPython would write to stderr goes to stderr; everything else goes to `error`."**

- Split the overloaded `Error::Execution` → added `Error::PythonException` (the traceback, CPython-style). The guest's inner logical error maps to it; wasmtime/trap/store failures stay `Error::Execution` (machinery).
- NUL bytes in code are rejected host-side, classified as a sandbox/input error (not a script exception).
- New gRPC `FailureKind` enum on `ExecuteResult`: `SCRIPT_EXCEPTION`, `TIMEOUT`, `FUEL_EXHAUSTED`, `SANDBOX_ERROR`, `CANCELLED` — callers branch programmatically instead of string-matching.
- For a script exception, the traceback is in `stderr` and `error` is **empty**; `error` is reserved for sandbox failures.
- Python bindings: `PythonException` maps to `ExecutionError`, preserving existing behavior.

| Failure | `success` | `failure_kind` | `error` | `stderr` |
|---|---|---|---|---|
| clean run | true | UNSPECIFIED | "" | captured |
| uncaught exception | false | SCRIPT_EXCEPTION | "" | traceback |
| timeout / fuel / trap / bad input | false | TIMEOUT/FUEL_EXHAUSTED/SANDBOX_ERROR | message | partial |

## ⚠️ Breaking (gRPC consumers)
`ExecuteResult.error` is now **empty for an uncaught script exception** — read `stderr` for the traceback and `failure_kind` to classify. External Go services must migrate to `failure_kind` + `stderr`.

## Tests
- gRPC e2e: script-exception (`failure_kind=SCRIPT_EXCEPTION`, `error=""`, traceback in stream + stderr, pre-exception stdout preserved), timeout (`TIMEOUT` + populated `error`), NUL bytes (`SANDBOX_ERROR`).
- Library: a raise is `Error::PythonException`; NUL bytes are `Error::Execution`, not a script exception.
- Full workspace suite green (537 tests); clippy clean; Python bindings compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
