### PR TITLE
fix(ci): release-plz uses a GitHub App token so releases trigger downstream

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,11 +18,24 @@ jobs:
       contents: write
       id-token: write
     steps:
+      # Mint a GitHub App installation token. release-plz must NOT use the
+      # default GITHUB_TOKEN to push tags / create releases: GitHub suppresses
+      # workflow runs triggered by the default token, so the cargo-dist
+      # (release.yml) and Python/JS release workflows downstream of these
+      # tags/releases never fire. An App token is exempt from that rule.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -33,7 +46,7 @@ jobs:
           command: release
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -47,11 +60,22 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # Use an App token so the release PR is opened by the App (not the
+      # default token), which lets the PR's CI checks run. See the note in the
+      # release job above.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -77,4 +101,4 @@ jobs:
           command: release-pr
           config: release-plz.toml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,14 @@ git_tag_enable = true
 # Create GitHub releases
 git_release_enable = true
 
+# eryx-precompile ships prebuilt binaries via cargo-dist (.github/workflows/release.yml),
+# which creates AND populates its GitHub release when the tag is pushed. If release-plz
+# also created that release, cargo-dist's `gh release create` would collide and fail.
+# So let release-plz create only the tag (which triggers cargo-dist) — not the release.
+[[package]]
+name = "eryx-precompile"
+git_release_enable = false
+
 [changelog]
 body = """
 


### PR DESCRIPTION
## Problem

`release-plz` pushed tags and created GitHub releases with the default `GITHUB_TOKEN`. GitHub **deliberately suppresses workflow runs triggered by the default token** (anti-recursion), so every workflow downstream of a release-plz tag/release never fired automatically:

| Workflow | Trigger | Result |
|---|---|---|
| `release.yml` (cargo-dist → eryx-precompile binaries) | `push: tags` | never fired |
| `python-release.yml` (PyPI wheels) | `release: published` | never fired |
| `js-release.yml` (npm) | `release: published` | never fired |

These only ever ran when a human **re-pushed the tag by hand** (every successful cargo-dist run through v0.4.9 was `event=push, actor=sd2k`). The fully bot-driven `v0.4.10` and `v0.5.0` shipped with **zero** binaries, wheels, or npm package — `eryx-precompile-v0.5.0` has no assets, while `eryx-precompile-v0.4.9` has all 11.

## Fix

- **App token (`release-plz.yml`)** — mint a GitHub App installation token in both jobs and use it for checkout + the release-plz action. Tags/releases created by an App token are exempt from the anti-recursion rule, so all three downstream workflows fire. Using it in the PR job too lets the release PR's own CI run.
- **`release-plz.toml`** — disable `git_release` for `eryx-precompile`. cargo-dist creates *and* populates that release itself; if release-plz also created it, cargo-dist's `gh release create` would collide and fail (this is why the manual fix required deleting the release first). release-plz now creates only the tag, which triggers cargo-dist.

## Prerequisite (done)

GitHub App created under `eryx-org` with Contents + Pull requests write, installed on the repo. Repo now has variable `RELEASE_PLZ_APP_ID` and secret `RELEASE_PLZ_APP_PRIVATE_KEY`.

## Validation

Can't be fully exercised without a release — the next release-plz PR merge will push tags via the App token and should trigger cargo-dist + PyPI + npm automatically. v0.5.0 needs a separate manual backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)