### PR TITLE
feat(ci): publish version-tagged Docker images on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+    # Release tags (pushed by release-plz via the GitHub App token) so the
+    # docker job can publish a version-tagged image, e.g. sd2k/eryx-server:0.5.0.
+    tags: ['eryx-v[0-9]+.[0-9]+.[0-9]+']
   pull_request:
     branches: [main]
 
@@ -680,6 +683,7 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.fork != true
       && github.actor != 'dependabot[bot]'
+      && github.ref_type != 'tag'
       && (github.event_name == 'push'
       || needs.changes.outputs.core == 'true'
       || needs.changes.outputs.js == 'true'
@@ -813,10 +817,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: sd2k/eryx-server
+          # On main: sha + branch + latest. On a release tag (eryx-v0.5.0):
+          # the version tags 0.5.0 and 0.5 (type=match strips the eryx-v prefix).
+          # latest stays tied to main and is not moved by tag builds.
           tags: |
             type=sha,prefix=
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
+            type=match,pattern=\d+.\d+.\d+,group=0
+            type=match,pattern=\d+.\d+,group=0
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Problem

`sd2k/eryx-server` has only `latest`, `main`, and per-commit SHA tags — **no version tags** (e.g. `0.5.0`). Two reasons:

- The docker job (`ci.yml`) tags via `type=sha` / branch / `latest` only — there's no `type=semver`/`match` rule, so a version number is never produced.
- It rides on `main`-push CI, which carries no version and can be cancelled by concurrency — the v0.5.0 release commit's run *was* cancelled, so not even its SHA image exists.

## Fix

- Trigger CI on the `eryx-v*` release tag (pushed by release-plz via the App token from #257), so the docker job runs for the release.
- Add `type=match` rules so the image is tagged `0.5.0` and `0.5` (strips the `eryx-v` prefix). These only match tag refs, so main builds are unchanged and `latest` stays tied to main.
- Guard `deploy-demo` with `github.ref_type != 'tag'` to avoid a junk Cloudflare preview deploy on the release tag.

Depends on #257 (App token) — without it the release tag wouldn't trigger this workflow.

## Note

The full CI suite runs on the release tag (acts as a release gate). If you'd rather only the docker + runtime-build jobs run on tags, that's an easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)