### PR TITLE
feat(eryx-vfs): snapshot / restore / clone for InMemoryStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,8 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "fs-set-times",
+ "serde",
+ "serde_json",
  "system-interface",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/eryx-vfs/Cargo.toml
+++ b/crates/eryx-vfs/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "1"
 cap-fs-ext = "3"
 cap-std = "3"
 fs-set-times = "0.20"
+serde = { workspace = true, optional = true }
 system-interface = { version = "0.27", features = ["cap_std_impls"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
@@ -23,7 +24,21 @@ wasmtime.workspace = true
 wasmtime-wasi.workspace = true
 wasmtime-wasi-io.workspace = true
 
+[features]
+## Derive serde `Serialize`/`Deserialize` on the snapshot types, enabling
+## persistence of an `InMemoryStorage` snapshot to bytes.
+serde = ["dep:serde"]
+
+# The repo's feature-combinations CI runs `cargo check-all-features -- -p eryx`,
+# which pins `-p eryx` while enumerating every workspace crate's features —
+# so a non-eryx feature like this one is checked as `-p eryx --features serde`
+# and errors ("package 'eryx' does not contain this feature"). Exclude it from
+# the powerset; it's exercised directly by eryx-vfs's own tests + downstream.
+[package.metadata.cargo-all-features]
+denylist = ["serde"]
+
 [dev-dependencies]
+serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/eryx-vfs/src/lib.rs
+++ b/crates/eryx-vfs/src/lib.rs
@@ -51,7 +51,7 @@ pub use linker::{HybridVfsView, VfsView, add_hybrid_vfs_to_linker, add_vfs_to_li
 pub use scrubbing::{
     FileScrubPolicy as VfsFileScrubPolicy, ScrubbingStorage, SecretConfig as VfsSecretConfig,
 };
-pub use storage::{ArcStorage, DirEntry, InMemoryStorage, Metadata, VfsStorage};
+pub use storage::{ArcStorage, DirEntry, InMemorySnapshot, InMemoryStorage, Metadata, VfsStorage};
 pub use wasi_impl::{VfsCtx, VfsDescriptor, VfsReaddirIterator, VfsState};
 
 // Re-export permission types from wasmtime-wasi for convenience

--- a/crates/eryx-vfs/src/storage.rs
+++ b/crates/eryx-vfs/src/storage.rs
@@ -52,6 +52,16 @@ pub struct DirEntry {
 /// All paths are absolute paths starting with `/`.
 #[async_trait]
 pub trait VfsStorage: Send + Sync {
+    /// Downcasting hook for storage-specific operations (e.g. capturing an
+    /// in-memory snapshot).
+    ///
+    /// Concrete storages that support downcasting return `Some(self)`; the
+    /// default is `None`. [`InMemoryStorage`] returns `Some` so callers can
+    /// reach [`InMemoryStorage::snapshot`].
+    fn as_any(&self) -> Option<&dyn core::any::Any> {
+        None
+    }
+
     /// Read file contents.
     async fn read(&self, path: &str) -> VfsResult<Vec<u8>>;
 
@@ -194,7 +204,8 @@ impl VfsStorage for ArcStorage {
 /// Combining files and directories into a single struct allows us to use
 /// a single `RwLock`, avoiding potential deadlock issues from acquiring
 /// multiple locks.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct StorageState {
     /// File contents: path -> data
     files: HashMap<String, FileData>,
@@ -213,11 +224,28 @@ pub struct InMemoryStorage {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct FileData {
     content: Vec<u8>,
     created: SystemTime,
     modified: SystemTime,
     accessed: SystemTime,
+}
+
+/// A clonable, optionally-serializable snapshot of an [`InMemoryStorage`]'s
+/// complete contents (all files and directories).
+///
+/// Produced by [`InMemoryStorage::snapshot`]. Apply it to an existing storage
+/// with [`InMemoryStorage::restore`] (in place, preserving the storage's
+/// identity so existing `Arc` references stay valid), or create an independent
+/// copy with [`InMemoryStorage::from_snapshot`] (for forking a session).
+///
+/// With the `serde` feature, this derives `Serialize`/`Deserialize` so it can be
+/// persisted to bytes.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct InMemorySnapshot {
+    state: StorageState,
 }
 
 impl Default for InMemoryStorage {
@@ -237,6 +265,36 @@ impl InMemoryStorage {
                 files: HashMap::new(),
                 directories,
             }),
+        }
+    }
+
+    /// Capture the entire contents (files and directories) as a snapshot.
+    ///
+    /// The snapshot is an independent copy; later mutations to this storage do
+    /// not affect it.
+    pub async fn snapshot(&self) -> InMemorySnapshot {
+        InMemorySnapshot {
+            state: self.state.read().await.clone(),
+        }
+    }
+
+    /// Replace this storage's entire contents with a snapshot, in place.
+    ///
+    /// The storage's identity is preserved, so any `Arc<dyn VfsStorage>` handles
+    /// (e.g. those wired into a running sandbox) continue to refer to it and see
+    /// the restored contents.
+    pub async fn restore(&self, snapshot: &InMemorySnapshot) {
+        *self.state.write().await = snapshot.state.clone();
+    }
+
+    /// Create a new, independent storage initialized from a snapshot.
+    ///
+    /// Useful for forking a session: the returned storage shares no state with
+    /// the original, so the two can diverge freely.
+    #[must_use]
+    pub fn from_snapshot(snapshot: &InMemorySnapshot) -> Self {
+        Self {
+            state: RwLock::new(snapshot.state.clone()),
         }
     }
 
@@ -298,6 +356,10 @@ impl InMemoryStorage {
 
 #[async_trait]
 impl VfsStorage for InMemoryStorage {
+    fn as_any(&self) -> Option<&dyn core::any::Any> {
+        Some(self)
+    }
+
     async fn read(&self, path: &str) -> VfsResult<Vec<u8>> {
         let path = Self::normalize_path(path)?;
         let state = self.state.read().await;
@@ -694,6 +756,44 @@ impl VfsStorage for InMemoryStorage {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_snapshot_restore_and_fork() {
+        let storage = InMemoryStorage::new();
+        storage.mkdir("/data").await.unwrap();
+        storage.write("/data/a.txt", b"original").await.unwrap();
+
+        // Snapshot, then mutate.
+        let snap = storage.snapshot().await;
+        storage.write("/data/a.txt", b"changed").await.unwrap();
+        storage.write("/data/b.txt", b"new").await.unwrap();
+
+        // Restore in place: back to the snapshot, b.txt gone.
+        storage.restore(&snap).await;
+        assert_eq!(storage.read("/data/a.txt").await.unwrap(), b"original");
+        assert!(storage.read("/data/b.txt").await.is_err());
+
+        // Fork: an independent copy that diverges without affecting the original.
+        let forked = InMemoryStorage::from_snapshot(&snap);
+        forked.write("/data/a.txt", b"forked").await.unwrap();
+        assert_eq!(forked.read("/data/a.txt").await.unwrap(), b"forked");
+        assert_eq!(storage.read("/data/a.txt").await.unwrap(), b"original");
+    }
+
+    #[cfg(feature = "serde")]
+    #[tokio::test]
+    async fn test_snapshot_serde_round_trip() {
+        let storage = InMemoryStorage::new();
+        storage.mkdir("/d").await.unwrap();
+        storage.write("/d/f.txt", b"payload").await.unwrap();
+
+        let snap = storage.snapshot().await;
+        let bytes = serde_json::to_vec(&snap).unwrap();
+        let restored: InMemorySnapshot = serde_json::from_slice(&bytes).unwrap();
+
+        let fresh = InMemoryStorage::from_snapshot(&restored);
+        assert_eq!(fresh.read("/d/f.txt").await.unwrap(), b"payload");
+    }
 
     #[tokio::test]
     async fn test_file_operations() {


### PR DESCRIPTION
Adds the ability to capture an `InMemoryStorage`'s full contents and restore or fork from it — for session checkpointing in embedders (e.g. [conch](https://github.com/sd2k/conch)).

## API
- **`InMemorySnapshot`** — a clonable, optionally-serializable capture of all files + directories.
- **`InMemoryStorage::snapshot()`** — capture current contents.
- **`InMemoryStorage::restore(&snapshot)`** — replace contents **in place** (preserves the storage's identity, so live `Arc<dyn VfsStorage>` handles wired into a running sandbox see the restored contents).
- **`InMemoryStorage::from_snapshot(&snapshot)`** — create a new, independent storage (for forking a session).
- **`VfsStorage::as_any()`** — downcast hook (default `None`; `InMemoryStorage` returns `Some`) so type-erased `Arc<dyn VfsStorage>` holders can reach the in-memory API.

## Feature flag
New optional **`serde`** feature derives `Serialize`/`Deserialize` on the snapshot types, enabling persistence to bytes. Off by default — no new required deps.

## Tests
`snapshot` → mutate → `restore` (in place) and `from_snapshot` (isolated fork); plus a serde round-trip under the `serde` feature. Builds cleanly with and without the feature; clippy `-D warnings` clean. 29 eryx-vfs tests pass.

> Consumed by conch's session snapshot/restore/fork feature (sd2k/conch#71), which currently pins this via a git `[patch]`. Tagging a release (0.6.0) afterwards lets conch drop the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)