### PR TITLE
ci: pin mise and exclude oxc-parser bindings from aube trust gate

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -11,4 +11,9 @@ runs:
     - name: Install mise
       uses: jdx/mise-action@v3
       with:
+        # Pinned for reproducibility: mise-action installs the latest mise by
+        # default, and an auto-upgrade to 2026.8.2 broke CI (its new aube
+        # supply-chain trust gate rejected a jco transitive dep). See the
+        # trust_policy_excludes note in js/mise.toml. Bump deliberately.
+        version: 2026.8.2
         cache: false # We handle caching ourselves to include ~/.rustup

--- a/js/mise.toml
+++ b/js/mise.toml
@@ -1,6 +1,13 @@
 [tools]
 node = "24"
-"npm:@bytecodealliance/jco" = "1.16.1"
+# trust_policy_excludes: mise 2026.8.2's aube npm backend added a "no-downgrade"
+# supply-chain trust gate. jco's transitive dep @oxc-parser/binding-*@0.76.0
+# dropped its provenance attestation (0.13.3 had it; oxc restored it in 0.90.0+),
+# which the gate flags as a downgrade and refuses to install. Bumping jco does
+# NOT help — its dependency tree still resolves oxc 0.76.0 (verified on 1.27.0).
+# Remove this exclude once jco pulls a signed oxc (>=0.90.0) or mise stops
+# flagging it. See https://aube.jdx.dev/security#trust-policy
+"npm:@bytecodealliance/jco" = { version = "1.16.1", trust_policy_excludes = ["@oxc-parser/binding-*"] }
 
 # =============================================================================
 # JavaScript bindings tasks (browser/Node.js via jco)


### PR DESCRIPTION
## Problem

CI on `main` is red (JS bindings + Deploy Demo jobs). mise **2026.8.2** added a "no-downgrade" supply-chain trust gate to its `aube` npm backend. jco's transitive dep `@oxc-parser/binding-*@0.76.0` **dropped its provenance attestation** (present at 0.13.3, restored by oxc in 0.90.0+), which the gate flags as a downgrade and refuses to install:

```
trust downgrade for @oxc-parser/binding-darwin-arm64@0.76.0 (trustPolicy=no-downgrade):
earlier published version 0.13.3 had provenance attestation but this version has no trust evidence
```

Nothing in the repo changed — mise-action installs the latest mise by default, and the auto-upgrade to 2026.8.2 introduced the gate.

## Why not just bump jco?

It doesn't help. The chain is `jco → @bytecodealliance/componentize-js → oxc-parser`, and componentize-js pins `oxc-parser: ^0.76.0`. Caret on a `0.x` version caps resolution below `0.77.0`, so the signed `0.90.0` is unreachable. Verified: jco 1.27.0 still resolves `oxc-parser@0.76.0` and fails identically. The real fix belongs upstream in ComponentizeJS (bump the range to `^0.90.0`) — tracked separately; not on a timeline that unblocks `main`.

## Change

- **`js/mise.toml`**: add `trust_policy_excludes = ["@oxc-parser/binding-*"]` to the jco tool (one glob covers all platform bindings). jco stays at the known-good `1.16.1`, so no build-compat risk.
- **`.github/actions/setup-rust/action.yml`**: pin mise to `2026.8.2` so a future auto-upgrade can't reintroduce a surprise. Covers both failing jobs (they share this composite action).

## Verification

Reproduced the failure and verified the fix locally under mise **2026.8.2** (the gated version): `mise install` fails on jco without the exclude, and reports **"all tools are installed"** with it.

## Follow-up

Remove the exclude once jco pulls a signed oxc (`≥0.90.0`) via a componentize-js release, or mise stops flagging it. `0.76.0` itself will never be re-signed (npm publishes are immutable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)