### PR TITLE
ci: keep Renovate lockstep groups intact and complete the Rust toolchain group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,18 @@
     schedule: ["before 6am on monday"],
   },
 
+  // ------------------------------------------------------------------
+  // Security updates are left to Dependabot, which is already enabled on
+  // this repo. Renovate's vulnerabilityAlerts defaults force groupName to
+  // null, so an advisory bumps the vulnerable crate on its own and tears
+  // apart the lockstep groups below — it opened opentelemetry_sdk 0.32
+  // against opentelemetry 0.31, and a pyo3 bump that would not resolve at
+  // all. The grouped PRs carry the same fixes with the group intact.
+  // ------------------------------------------------------------------
+  vulnerabilityAlerts: {
+    enabled: false,
+  },
+
   packageRules: [
     // ------------------------------------------------------------------
     // Internal / path dependencies — never bump these.
@@ -41,9 +53,16 @@
     // wasmtime N embeds the wasm-tools 0.(199+N) crates (wasmtime 44 <->
     // wasm-tools 0.243), and mise's `cargo:wasm-tools` CLI (1.243) tracks
     // the same line. Bump all of them in a single PR or the build breaks.
+    //
+    // separateMajorMinor is off on every strict-lockstep group below.
+    // Left on, Renovate splits a group into a major PR and a minor/patch
+    // PR whenever its members' next hops differ in update type — which let
+    // wasm-tools go 0.243 -> 0.255 while wasmtime stayed on 44, the exact
+    // mismatch the group exists to prevent.
     // ------------------------------------------------------------------
     {
       groupName: "wasmtime & wasm-tools",
+      separateMajorMinor: false,
       matchPackageNames: [
         "wasmtime",
         "wasmtime-wasi",
@@ -65,6 +84,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "wasm-bindgen",
+      separateMajorMinor: false,
       matchPackageNames: [
         "wasm-bindgen",
         "wasm-bindgen-cli",
@@ -84,6 +104,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "bytecodealliance (jco)",
+      separateMajorMinor: false,
       matchPackageNames: [
         "@bytecodealliance/jco",
         "@bytecodealliance/preview2-shim",
@@ -95,6 +116,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "pyo3",
+      separateMajorMinor: false,
       matchPackageNames: [
         "pyo3",
         "pyo3-async-runtimes",
@@ -109,6 +131,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "opentelemetry",
+      separateMajorMinor: false,
       matchPackageNames: [
         "opentelemetry",
         "opentelemetry_sdk",
@@ -125,6 +148,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "tonic & prost",
+      separateMajorMinor: false,
       matchPackageNames: [
         "tonic",
         "tonic-prost",
@@ -142,6 +166,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "rustls",
+      separateMajorMinor: false,
       matchPackageNames: [
         "rustls",
         "tokio-rustls",
@@ -155,6 +180,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "cap-std",
+      separateMajorMinor: false,
       matchPackageNames: ["cap-std", "cap-fs-ext"],
     },
 
@@ -163,6 +189,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "metrics",
+      separateMajorMinor: false,
       matchPackageNames: ["metrics", "metrics-exporter-prometheus"],
     },
 
@@ -172,6 +199,7 @@
     // ------------------------------------------------------------------
     {
       groupName: "rustcrypto-hashing",
+      separateMajorMinor: false,
       matchPackageNames: ["hmac", "sha2"],
     },
 
@@ -192,6 +220,8 @@
     // ------------------------------------------------------------------
     // Convenience groups: same-org crates that release compatibly — group
     // to cut PR noise (not strict lockstep, but always safe together).
+    // These keep the default major/minor split, since a major bump in one
+    // member is worth reviewing on its own.
     // ------------------------------------------------------------------
     {
       groupName: "tokio",
@@ -239,7 +269,11 @@
     {
       groupName: "Rust toolchain",
       matchManagers: ["mise"],
-      matchPackageNames: ["rust"],
+      // matchDepNames, not matchPackageNames: the mise manager resolves the
+      // `rust` tool to packageName "rust-lang/rust" (datasource github-tags),
+      // so matching on "rust" as a package name silently misses it and mise
+      // splits off into its own PR.
+      matchDepNames: ["rust"],
     },
 
     // ------------------------------------------------------------------
@@ -268,6 +302,27 @@
       depNameTemplate: "rust",
       datasourceTemplate: "docker",
       versioningTemplate: "semver",
+    },
+
+    // ------------------------------------------------------------------
+    // The MSRV job pins its toolchain in an inline mise config passed to
+    // jdx/mise-action (`mise_toml: |`). The github-actions manager only
+    // reads `uses:`, and the mise manager only reads mise.toml files, so
+    // nothing sees this pin — it sat at 1.92 while the rest of the
+    // toolchain moved. Anchor on the [tools] header so this can't match
+    // an unrelated `rust = "..."` elsewhere in a workflow.
+    // ------------------------------------------------------------------
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      matchStrings: [
+        "\\[tools\\]\\s*\\n\\s*rust\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\"",
+      ],
+      depNameTemplate: "rust",
+      datasourceTemplate: "docker",
+      // docker versioning, not semver: this pin is the two-component "1.92"
+      // form, which semver won't parse.
+      versioningTemplate: "docker",
     },
   ],
 }


### PR DESCRIPTION
Three fixes to the Renovate config, all found by dry-running Renovate 44.14.3 against the repo and reading the resulting branch plan.

## `separateMajorMinor: false` on the strict-lockstep groups

`groupName` keeps packages in one PR, but it doesn't stop Renovate splitting that group across a major PR and a minor/patch PR when its members' next hops differ in update type. That tore the wasmtime group in half:

| | wasmtime | wasm-tools crates |
|---|---|---|
| #279 | `44.0.2` → `44.0.3` (patch) | `0.243` → `0.255` (minor) |
| #281 | `44.0.2` → `47.0.0` (major) | — |

Our own comment says wasmtime N embeds wasm-tools 0.(199+N), so 44 ↔ 0.243. #279 moved wasm-tools to 0.255 while pinning wasmtime at 44 — the exact mismatch the group exists to prevent — and failed on `error[E0609]: no field 'name' on type 'wasmparser::Imports<'_>'`.

Applied to every group whose members can genuinely diverge in update type: wasmtime & wasm-tools, wasm-bindgen, jco, pyo3, opentelemetry, tonic & prost, rustls, cap-std, metrics, rustcrypto-hashing. The convenience groups (tokio, serde, proc-macro, svelte, vite, pytest, tracing) keep the default split — a major bump in one member is worth reviewing on its own. "Rust toolchain" doesn't need it; every member resolves to the same `rust` package.

## `vulnerabilityAlerts: { enabled: false }`

Renovate's built-in defaults for advisory-driven updates include `groupName: null`, so a security bump always lands on an isolated branch and can never respect a lockstep group. That gave us #271 (opentelemetry_sdk 0.32 against opentelemetry 0.31) and #272 (a pyo3 bump that wouldn't resolve — `failed to select a version for pyo3`).

Dependabot security updates are already enabled on this repo, and the grouped PRs (#278, #280) carry the same fixes with the group intact.

## Rust toolchain group was reaching only two of its four locations

#284 bumped `Cargo.toml` and the Dockerfile but left `mise.toml` and `ci.yml` on 1.92.

- The mise rule matched `matchPackageNames: ["rust"]`, but the mise manager resolves the tool to `packageName: "rust-lang/rust"` (datasource `github-tags`). The rule never fired and mise.toml split off into `renovate/rust-1.x`. Switched to `matchDepNames`.
- The MSRV job pins its toolchain in an inline `mise_toml: |` block passed to `jdx/mise-action`. No manager reads that — github-actions only parses `uses:`, mise only globs mise.toml files. Added a customManager anchored on the `[tools]` header so it can't drift onto an unrelated `rust = "..."`. Uses `versioning: "docker"` because the pin is the two-component `1.92` form, which `semver` won't parse.

## Verification

Dry run (`--platform=local --dry-run=full`) before and after:

- 49 → 43 branches
- `major-wasmtime-and-wasm-tools`, `major-cap-std`, `major-rustls` gone
- `crate-pyo3-vulnerability`, `crate-opentelemetry_sdk-vulnerability` gone
- `renovate/rust-1.x` gone; `Cargo.toml` (`1.92.0`→`1.97.1`), Dockerfile ×2 (`1.92-bookworm`→`1.97-bookworm`), `mise.toml` (`1.92`→`1.97.1`) and `ci.yml` (`1.92`→`1.97`) all land in a single `renovate/rust-toolchain` branch

`renovate-config-validator` passes.

## Note on existing PRs

Renovate will rewrite the open branches on its next run after this merges. If #284 is merged first, mise.toml and ci.yml stay at 1.92 and a follow-up PR will cover just those two.

This fixes the group *tearing*, but not the *pairing* — Renovate still takes each package to its own latest, so a collapsed wasmtime PR will pair wasmtime 47 with wasm-tools 0.255 rather than the 0.246 the 199+N formula wants. Nothing in Renovate can express a cross-repo version offset; that one still needs a hand-edit. Noted in the group's comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)