### PR TITLE
ci: fix main after cargo-rail 0.21 bump, and stop mise.toml changes skipping CI

### DIFF
--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -9,24 +9,10 @@ targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
 include_paths = true
 include_renamed = false
 
-pin_transitives = false  # we don't use workspace-hack crates
-transitive_host = "root"
-
 strict_version_compat = true
 exact_pin_handling = "warn"
 major_version_conflict = "warn"
-
-msrv = true
-msrv_source = "workspace"  # use rust-version from workspace Cargo.toml
-
-detect_unused = true
-remove_unused = true
-sort_dependencies = false
-
-prune_dead_features = true
 preserve_features = []
-detect_undeclared_features = true
-fix_undeclared_features = true
 skip_undeclared_patterns = [
   "default",
   "std",
@@ -39,14 +25,12 @@ skip_undeclared_patterns = [
 exclude = ["eryx-wasm-runtime"]
 include = []
 max_backups = 3
+msrv_policy = { mode = "compute", source = "workspace" }
 
 
 [release]
 tag_prefix = "v"
 tag_format = "{crate}-{prefix}{version}"
-require_clean = true
-publish_delay = 5
-create_github_release = false
 sign_tags = false
 changelog_path = "CHANGELOG.md"
 changelog_relative_to = "crate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
               - 'Cargo.toml'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
+              # Tool versions and the cargo-rail config drive what every Rust
+              # job actually runs. Without these, a Renovate bump that touches
+              # only mise.toml skips all of CI and merges green — which is how
+              # cargo-rail 0.8.1 -> 0.21.0 (#297) landed and broke main.
+              - 'mise.toml'
+              - '.config/rail.toml'
             server:
               - 'crates/eryx-server/**'
             python:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,113 +14,81 @@ repository = "https://github.com/eryx-org/eryx"
 authors = ["Ben Sully <ben.sully88@gmail.com>"]
 
 [workspace.dependencies]
+# Sorted alphabetically by `cargo rail unify`, which sorts unconditionally
+# since 0.21 (the unify.sort_dependencies opt-out is gone). Purpose notes
+# therefore ride on the dependency itself rather than sitting above a block
+# — a header only stays true until the next dependency sorts underneath it.
+# Self-explanatory crates are left unannotated.
 anyhow = "1.0"
 async-trait = "0.1"
-
-# Benchmarking
-criterion = { version = "0.8", features = ["async_tokio"] }
-crossterm = "0.28"
+blake3 = "1.8"
+clap = { version = "^4.5.57", features = ["derive"] } #unified
+criterion = { version = "0.8", features = ["async_tokio"] } # benchmarking
+crossterm = "0.28"                                          # terminal control
+dashmap = "6"                                               # concurrent maps
 eryx = { path = "crates/eryx", version = "^0.5.0" }
 eryx-macros = { path = "crates/eryx-macros", version = "^0.5.0" }
+eryx-runtime = { path = "crates/eryx-runtime", version = "^0.5.0" } #unified
+eryx-vfs = { path = "crates/eryx-vfs", version = "^0.5.0" } #unified
 flate2 = "1.0"
 futures = "0.3"
 futures-concurrency = "7.6"
 futures-lite = "2.6"
+hex = "0.4"
+hmac = "0.12"
+js-sys = "0.3"          # browser WASM bindings
 lending-stream = "1.0"
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false, features = ["http-listener"] }
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+opentelemetry_sdk = "0.32"
+prost = "0.14"          # gRPC (with tonic)
 pyo3 = { version = "^0.29.0", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 pythonize = "0.29"
-
-# JSON Schema
-schemars = "1.0.0-alpha.17"
-
-# Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-
-# Hashing / HMAC
-blake3 = "1.8"
-hex = "0.4"
-hmac = "0.12"
-sha2 = "0.10"
-
-# Random number generation for secret placeholders
-rand = "0.8"
+rand = "0.8"            # secret placeholder generation
+rcgen = "0.13"          # test certificate generation
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider"] }
-
-# Archive extraction
-tar = "0.4"
-tempfile = "3.20"
-
-# Error handling
-thiserror = "2.0"
-# Async runtime
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = "0.7"
-
-# TLS
+rmcp = "1.4"            # Model Context Protocol SDK
 rustls = "0.23"
 rustls-pemfile = "2.0"
+schemars = "1.0.0-alpha.17" # JSON Schema
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.10"
+tar = "0.4"
+tempfile = "3.20"
+thiserror = "2.0"
+tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.26"
-webpki-roots = "0.26"
-rcgen = "0.13"
-rmcp = "1.4"
-
-# gRPC
+tokio-stream = "0.1"
+tokio-util = "0.7"
 tonic = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
-prost = "0.14"
-
-# Unique identifiers
-uuid = "1"
-
-# Concurrent maps
-dashmap = "6"
-
-# Metrics
-metrics = "0.24"
-metrics-exporter-prometheus = { version = "0.18.1", default-features = false, features = ["http-listener"] }
-
-# Telemetry
-opentelemetry = "0.32"
-opentelemetry_sdk = "0.32"
-opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
-tracing-opentelemetry = "0.33"
-tracing-error = "0.2"
-
-# Utilities
 tracing = "0.1"
-
-# Directory walking
+tracing-error = "0.2"
+tracing-opentelemetry = "0.33"
+uuid = "1"
 walkdir = "2.5"
+wasm-bindgen = "0.2"    # browser WASM bindings
 wasm-encoder = "0.243"
 wasmparser = "0.243"
-
-# WebAssembly runtime (v40+ required for async component model)
-# 44.0.2 patches GHSA-2r75-cxrj-cmph (WASI path_open TRUNCATE bypasses FilePerms::WRITE)
+# wasmtime v40+ required for the async component model.
+# 44.0.2 patches GHSA-2r75-cxrj-cmph (WASI path_open TRUNCATE bypasses FilePerms::WRITE).
 wasmtime = { version = "44.0.2", features = ["component-model", "async"] }
 wasmtime-wasi = "44.0.2"
 wasmtime-wasi-io = "44.0.2"
 wasmtime-wizer = { version = "44.0.2", features = ["component-model", "wasmtime"] }
-
-# WebAssembly component linking and WIT parsing
+webpki-roots = "0.26"   # TLS trust roots
 wit-component = "0.243"
 wit-dylib = "0.243"
-
-# wit-dylib FFI for implementing interpreter interface (inlined from wasm-tools)
+# wit-dylib FFI for implementing the interpreter interface (inlined from wasm-tools).
 wit-dylib-ffi = { path = "crates/wit-dylib-ffi" }
 wit-parser = "0.243"
 zip = "2.0"
-
-# Compression
 zstd = "0.13"
-
-# Browser WASM bindings
-wasm-bindgen = "0.2"
-js-sys = "0.3"
-clap = { version = "^4.5.57", features = ["derive"] } #unified
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/crates/eryx-macros/Cargo.toml
+++ b/crates/eryx-macros/Cargo.toml
@@ -19,10 +19,10 @@ quote = "1"
 syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
 
 [dev-dependencies]
-eryx = { path = "../eryx", features = ["macros", "native-extensions", "vfs"] }
+eryx = { workspace = true, features = ["macros", "native-extensions", "vfs"] } #unified
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-schemars = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/eryx/Cargo.toml
+++ b/crates/eryx/Cargo.toml
@@ -93,41 +93,38 @@ name = "jinja2_sandbox"
 required-features = ["native-extensions", "embedded"]
 
 [dependencies]
-tokio = { workspace = true, features = ["sync", "net", "io-util", "time"] }
-tokio-util.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
+blake3 = { workspace = true, optional = true }
+eryx-macros = { workspace = true, optional = true } #unified
+eryx-runtime = { workspace = true, optional = true } #unified
+eryx-vfs = { workspace = true, optional = true } #unified
+flate2.workspace = true
 futures.workspace = true
+hex.workspace = true
+# Secrets support
+rand.workspace = true
+# TLS networking
+rustls.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
-wasmtime.workspace = true
-wasmtime-wasi.workspace = true
-tracing.workspace = true
 sha2.workspace = true
-blake3 = { workspace = true, optional = true }
-# Secrets support
-rand.workspace = true
-hex.workspace = true
-# Package support (always enabled)
-zip.workspace = true
-flate2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
-walkdir.workspace = true
-# TLS networking
-rustls.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["sync", "net", "io-util", "time"] }
 tokio-rustls.workspace = true
+tokio-util.workspace = true
+tracing.workspace = true
+walkdir.workspace = true
+wasmtime.workspace = true
+wasmtime-wasi.workspace = true
 webpki-roots.workspace = true
+# Package support (always enabled)
+zip.workspace = true
 # Embedded runtime/stdlib (optional)
 zstd = { workspace = true, optional = true }
-# Native extension support (optional)
-eryx-runtime = { path = "../eryx-runtime", version = "^0.5.0", optional = true }
-# Virtual filesystem support (optional)
-eryx-vfs = { path = "../eryx-vfs", version = "^0.5.0", optional = true }
-# Proc macro support (optional)
-eryx-macros = { path = "../eryx-macros", version = "^0.5.0", optional = true }
 
 [features]
 default = []
@@ -156,11 +153,11 @@ vfs = ["dep:eryx-vfs"]
 
 [dev-dependencies]
 async-trait.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 criterion.workspace = true
 crossterm.workspace = true
 rcgen.workspace = true
 rustls-pemfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Main is red on `Dependency Check`. Two separate problems, both traceable to #297.

## Why #297 merged green

#297 bumped cargo-rail **0.8.1 → 0.21.0** — 13 minor versions — by editing one line of `mise.toml`. Every job was skipped on that PR; only `Detect Changes`, `plan` and `Deploy Demo` ran.

`mise.toml` isn't in the `core` path filter, and `Dependency Check` gates on `github.event_name == 'push' || needs.changes.outputs.core == 'true'`. So the job that would have caught this never ran, the PR merged, and the `push` clause then forced it to run on main — where it failed.

This is systematic: **every tool Renovate manages through mise** (nextest, wasm-tools, wasm-bindgen-cli, mdbook, cargo-rail) currently skips the jobs that use it. Third commit adds `mise.toml` and `.config/rail.toml` to `core`.

There's an irony worth noting — `.config/rail.toml` already lists `mise.toml` under `[change-detection] infrastructure`, so cargo-rail itself treats it as invalidating the workspace. The Actions path filter just didn't agree.

## Why it fails

`cargo rail unify --check` exits 1: 0.21 hoists workspace-member path deps into `[workspace.dependencies]`, and `eryx-runtime` / `eryx-vfs` were missing. `eryx` and `eryx-macros` were already declared that way, so this just brings the other two in line.

0.21 **also sorts dependency tables unconditionally** — `unify.sort_dependencies` is deprecated and ignored. The config sets it to `false` and the output came out sorted regardless:

```
unify.sort_dependencies
  Deprecated: dependency edits are always deterministic.
```

(That field was added in loadingalias/cargo-rail#5 back in Dec 2025; 0.21 retired it. Unlike its deprecated neighbours it carries no *"preserves the old toggle during its migration window"* clause, which matches the observed behaviour.)

The sort detached ~7 of 17 grouping comments from the deps they described — `# Hashing / HMAC` over `clap`, `# Random number generation for secret placeholders` over `rcgen`/`reqwest`/`rmcp`, `# Browser WASM bindings` over `wasm-encoder`/`wasmparser`.

Restoring the headers would just defer the problem: with unconditional sorting, a header is only correct until the next dependency sorts underneath it. So the purpose notes now ride on the dependency itself, where a re-sort can't detach them. Self-explanatory crates are left unannotated, and the two long-form notes carrying real context (the wasmtime GHSA patch level, wit-dylib-ffi's provenance) stay as block comments.

Lockstep relationships are unaffected — those live in `renovate.json5`, which is a far more reliable home for them than comment adjacency.

## Also included

`cargo rail config migrate` for the 13 deprecated fields — mostly toggles that became unconditional, plus `unify.msrv` + `unify.msrv_source` → `unify.msrv_policy`. Pure warning noise, none of it affected the exit status, but it takes the Dependency Check log from 13 warnings to zero. Kept as its own commit so it can be dropped independently.

## Verification

Run locally against cargo-rail 0.21.0:

- `cargo metadata` resolves; `path =` preserved on all four internal deps (the `--show-diff` summary elides it, but the written entries keep it)
- `cargo rail unify --check` → `status: no changes`, exit 0
- deprecation warnings: 13 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)