### PR TITLE
test(eryx-python): guard CPython finalization; fix libs/ rebuild tracking

### DIFF
--- a/crates/eryx-python/tests/test_gc_finalization.py
+++ b/crates/eryx-python/tests/test_gc_finalization.py
@@ -1,0 +1,45 @@
+"""Guards CPython object finalization inside the sandbox.
+
+These tests look like they test CPython itself, but they exist to catch a
+specific vendoring mistake: `crates/eryx-runtime/libs/libpython3.14.so` and
+`libc.so` must be built together from the same wasi-libc revision. Mixing
+vintages links cleanly and boots fine, but silently breaks refcount-based
+finalization — `__del__` never fires, so buffered writes never flush and files
+appear to vanish with no error. See docs/wasi-sdk-wasip2-migration.md.
+
+Both tests below were confirmed to fail against a deliberately mismatched
+libc/libpython pair. The cycle collector keeps working in that state, so only
+the refcount path is a reliable detector.
+"""
+
+import eryx
+
+
+def test_del_fires_on_refcount_drop():
+    sandbox = eryx.Sandbox()
+    result = sandbox.execute("""
+log = []
+
+
+class Probe:
+    def __del__(self):
+        log.append("deleted")
+
+
+for _ in range(5):
+    p = Probe()
+    del p
+
+result = log
+""")
+    assert result.result == ["deleted"] * 5
+
+
+def test_unclosed_file_is_flushed_on_finalization():
+    storage = eryx.VfsStorage()
+    session = eryx.Session(vfs=storage)
+
+    session.execute("open('/data/unclosed.txt', 'w').write('flushed')")
+    result = session.execute("print(open('/data/unclosed.txt').read())")
+
+    assert result.stdout == "flushed"

--- a/crates/eryx-python/tests/test_sandbox.py
+++ b/crates/eryx-python/tests/test_sandbox.py
@@ -686,9 +686,20 @@ else:
 """)
         assert "SUCCESS" in result.stdout, f"Test failed: {result.stdout}"
 
-    def test_async_tls_api_external(self, network_sandbox):
+    def test_async_tls_api_external(self):
         """Test the async _eryx_async TLS API with external service."""
-        result = network_sandbox.execute("""
+        # Per-op net timeouts must leave room for every host attempt inside the
+        # execution timeout. On the defaults (connect 30s, io 60s, execution
+        # 30s) one stalled host exhausts the whole budget, so the failure
+        # surfaces as a bare SandboxTimeoutError naming neither host nor step.
+        config = eryx.NetConfig(
+            allow_all_hosts=True, connect_timeout_ms=4000, io_timeout_ms=4000
+        )
+        sandbox = eryx.Sandbox(
+            network=config,
+            resource_limits=eryx.ResourceLimits(execution_timeout_ms=60000),
+        )
+        result = sandbox.execute("""
 import _eryx_async
 
 hosts = ["httpbin.org", "example.com", "www.google.com"]

--- a/crates/eryx-runtime/build.rs
+++ b/crates/eryx-runtime/build.rs
@@ -51,6 +51,13 @@ fn main() {
         "cargo::rerun-if-changed={}",
         manifest_dir.join("prebuilt").display()
     );
+    // Rerun if the vendored CPython/libc blobs are re-vendored. Without this a
+    // warm cargo cache keeps the previously linked runtime.wasm, so a lib swap
+    // silently tests the old component.
+    println!(
+        "cargo::rerun-if-changed={}",
+        manifest_dir.join("libs").display()
+    );
     // Rerun if docs.rs env changes
     println!("cargo::rerun-if-env-changed=DOCS_RS");
 


### PR DESCRIPTION
Follow-up to #331. That PR landed the real fix — re-vendoring `libpython3.14.so` and `libc.so` together against wasi-sdk-33 — but verified the GC repro ad-hoc without committing a test, so nothing stops the same mistake recurring. This adds that test, plus two related fixes found while validating it.

### 1. Permanent GC finalization test

`crates/eryx-python/tests/test_gc_finalization.py` makes the `Probe.__del__` repro a real test. Crucially, it was **confirmed to fail** against a deliberately mismatched libc/libpython pair, not merely to pass today:

```
test_del_fires_on_refcount_drop           -> []  instead of 5x 'deleted'
test_unclosed_file_is_flushed_on_final... -> ''  instead of 'flushed'
```

A cyclic-reference variant was written and then dropped: the cycle collector keeps working in the broken state, so it passed either way and guarded nothing. Only the refcount path is a valid detector — the module docstring records this so it isn't "helpfully" re-added.

### 2. `build.rs` was not tracking `libs/`

`crates/eryx-runtime/build.rs` declared `rerun-if-changed` for `src`, `clock_stubs.c`, `Cargo.toml`, `wit/` and `prebuilt/` — but **not** `libs/`, the vendored blobs it links into the component. Re-vendoring them therefore never re-ran the build script, and a warm cargo cache silently kept linking the **old** `runtime.wasm`.

This is the actual explanation for the "same commit builds differently" behaviour seen during the #331 work, which was initially suspected to be a wasm-tools race. Verified by A/B test: deleting `runtime.wasm` left it stale before this line was added, and regenerated it after.

### 3. `test_async_tls_api_external` could not fail cleanly by construction

This test looked like a network flake but was structurally broken. `NetConfig`'s defaults (`connect_timeout` 30s, `io_timeout` 60s) meet or exceed the sandbox's 30s `execution_timeout`, and `_eryx_async` passes `timeout_ms=0` to defer to the host. So the execution timeout always won, and the only reachable symptom was a bare `SandboxTimeoutError` naming neither host nor step — no diagnostic signal at all.

Now uses 4s per-op timeouts inside a 60s budget: worst case 3 hosts x 4 ops x 4s = 48s stays inside the budget, so a stalled host fails fast and identifies itself.

Note in-sandbox timers are not an option here: `_EryxLoop.time()` raises `NotImplementedError` and there is no `call_later`, so `asyncio.wait_for` cannot work inside the sandbox.

### Verification

- `310 passed` (308 baseline + 2 new) in the `crates/eryx-python` suite
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `mise run build-eryx-runtime` and both precompile paths clean (`--preinit` executes the runtime via wizer)
- Confirmed `libs/` is byte-identical to `main` — no vendored blobs changed here

Background and the corrected history are in `docs/wasi-sdk-wasip2-migration.md` (kept local, untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)