### PR TITLE
ci: install protoc without apt; bound the remaining apt call

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -355,5 +355,25 @@
       // form, which semver won't parse.
       versioningTemplate: "docker",
     },
+
+    // ------------------------------------------------------------------
+    // The protoc version installed by arduino/setup-protoc is a `version:`
+    // input, not a `uses:` ref, so the github-actions manager can't see it and
+    // the pin would otherwise sit still forever. Upstream tags are `v35.1`;
+    // the input takes the bare `35.1`, hence extractVersion. semver-coerced
+    // parses that two-component form and still treats `-rc` tags as unstable
+    // so release candidates aren't proposed.
+    // ------------------------------------------------------------------
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      matchStrings: [
+        "arduino/setup-protoc@[^\\n]+\\n\\s*with:\\s*\\n\\s*version:\\s*\"(?<currentValue>[\\d.]+)\"",
+      ],
+      depNameTemplate: "protocolbuffers/protobuf",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.+)$",
+      versioningTemplate: "semver-coerced",
+    },
   ],
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v8
@@ -270,10 +273,25 @@ jobs:
           ls -la crates/eryx-wasm-runtime/target/
           ls crates/eryx-wasm-runtime/tests/python-stdlib/ | head -10
 
-      - name: Install mold linker, clang, and protoc
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # `apt-daily`/`unattended-upgrades` runs on freshly booted runners and
+      # holds the dpkg/apt locks. apt waits for a held lock *forever* by
+      # default and prints nothing while it does, so a run that loses this race
+      # burns the full 6h job limit with no output — that is what hung Lint and
+      # Documentation on #256. DPkg::Lock::Timeout bounds the lock wait (apt
+      # then exits non-zero, so the failure is fast and retryable) and
+      # timeout-minutes is the backstop for anything else that stalls, such as
+      # an unresponsive archive mirror.
+      - name: Install mold linker and clang
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y mold clang protobuf-compiler
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y mold clang
 
       - name: Configure mold linker
         run: |
@@ -355,7 +373,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Problem

`Lint` and `Documentation` hung on **Install protoc** in #256. Not a protoc problem — `apt-get` was stuck:

- Attempt 1 sat on the step for **6 hours** (20:54 → 02:54) before hitting the default job limit.
- Attempt 2 hung the same way; several manual retries did too.
- The **same commit** passed the step in 44s five minutes earlier (run `32183879810`).
- Step duration had been creeping across recent runs: 11s → 44s → 119s → ∞.

`apt-get` waits on a held dpkg/apt lock **forever** by default and prints nothing while waiting. Freshly booted runners run `apt-daily`/`unattended-upgrades`, which holds those locks, so a job losing that race hangs silently instead of failing. Nothing in `ci.yml` bounded it — there is no `timeout-minutes` anywhere in the workflow — so one stuck apt burns a runner for 6h and blocks the PR with no diagnostic output.

## Change

**Take apt off the critical path for protoc.** `arduino/setup-protoc@v3` fetches a prebuilt release binary and caches it, so `Lint` and `Documentation` no longer touch apt at all.

**Bound the apt call that remains.** `Test` still needs apt for `mold` and `clang`:
- `-o DPkg::Lock::Timeout=120` caps the lock wait, so apt exits non-zero rather than blocking.
- `timeout-minutes: 5` is the backstop for anything else that stalls, e.g. an unresponsive mirror.

Either way a 6h silent hang becomes a fast, retryable failure.

**Keep the pin fresh.** The protoc version is a `version:` input rather than a `uses:` ref, so the `github-actions` manager can't see it — the same blind spot the MSRV `customManager` above it documents. Added a Renovate `customManager` (verified to match all three pin sites).

## Notes

- protoc goes 3.21.12 (Ubuntu) → 35.1. The protos are plain `proto3`, so this is backward compatible; `tonic-prost-build` only shells out to protoc for a descriptor set.
- `crates/eryx-server/Dockerfile` still apt-installs `protobuf-compiler`. Left as-is: container builds have no `unattended-upgrades` competing for the lock, so they aren't exposed to this race.
- Not addressed here: **no job in `ci.yml` sets `timeout-minutes`**, so any future hang anywhere still costs 6h. Worth a follow-up, but picking safe per-job values needs a look at normal runtimes (`Test` is ~17m) and I didn't want to risk false failures in a fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)