### PR TITLE
test(eryx): share pre-init bytes across preinit tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,13 @@
 # See https://nexte.st/docs/configuration/
 
+# A single `pre_initialize()` call already saturates several cores (wizer
+# instrumentation plus a full wasmtime compile of a 34MB component), so running
+# the preinit tests concurrently makes them thrash each other and the rest of
+# the suite. Serializing them also lets the first test populate the shared
+# pre-init cache in crates/eryx/tests/preinit.rs so the others just read it.
+[test-groups]
+preinit = { max-threads = 1 }
+
 [profile.default]
 # Print slow tests after the run
 slow-timeout = { period = "30s", terminate-after = 2 }
@@ -13,10 +21,14 @@ fail-fast = false
 # Number of retries for flaky tests (0 = no retries)
 retries = 0
 
+# Inherited by every profile, including `ci`.
+[[profile.default.overrides]]
+filter = 'binary_id(=eryx::preinit)'
+test-group = 'preinit'
+
 [profile.ci]
 # CI profile with stricter settings
 fail-fast = true
 retries = 2
+# Slow WASM component tests are reported at 60s and killed at 3x that.
 slow-timeout = { period = "60s", terminate-after = 3 }
-# Increase default timeout for slow WASM component tests
-default-timeout = "120s"

--- a/crates/eryx/tests/preinit.rs
+++ b/crates/eryx/tests/preinit.rs
@@ -10,8 +10,10 @@
 
 use eryx::Sandbox;
 use eryx::preinit::pre_initialize;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tokio::sync::{Mutex, OnceCell};
 
 /// Get the path to the Python stdlib for tests.
 fn get_stdlib_path() -> PathBuf {
@@ -19,6 +21,127 @@ fn get_stdlib_path() -> PathBuf {
         .parent()
         .unwrap()
         .join("eryx-wasm-runtime/tests/python-stdlib")
+}
+
+// =============================================================================
+// Shared pre-initialization
+// =============================================================================
+//
+// `pre_initialize` costs ~20s of CPU per call and saturates several cores on
+// its own (wizer instrumentation plus a full wasmtime compile of a 34MB
+// component). Every test below needs pre-initialized bytes, so without sharing
+// the group redoes that work once per test and thrashes CPU against itself and
+// the rest of the suite - enough to hit nextest's kill threshold in CI.
+//
+// Sharing has to work *across processes*: nextest runs each test in its own
+// process, so an in-process cache alone would share nothing under it. The bytes
+// are therefore cached on disk, keyed by nextest's per-run id so an entry can
+// never outlive the build that produced it. `.config/nextest.toml` puts these
+// tests in a single-threaded test group, so the first test computes the bytes
+// and the rest just read the file. The trade-off is attribution: a failing
+// pre-init is reported against whichever test happened to run first, not
+// necessarily `preinit_basic`.
+
+/// In-process cache, keyed by the pre-init arguments.
+///
+/// This is what shares the bytes under plain `cargo test`, where the whole
+/// binary is one process running tests on threads.
+static PREINIT_CACHE: OnceCell<Mutex<HashMap<String, Arc<Vec<u8>>>>> = OnceCell::const_new();
+
+/// Cache key for a set of pre-init imports, also used as the file name.
+fn cache_key(imports: &[&str]) -> String {
+    if imports.is_empty() {
+        "default".to_string()
+    } else {
+        format!("imports-{}", imports.join("-"))
+    }
+}
+
+/// Directory holding the on-disk pre-init cache for the current test run.
+///
+/// Keyed by `NEXTEST_RUN_ID` under nextest (one id shared by every test process
+/// in a run) and by pid otherwise, so entries are always fresh with respect to
+/// the runtime that produced them - a stale entry would silently test the wrong
+/// component.
+fn cache_dir() -> PathBuf {
+    let run_id =
+        std::env::var("NEXTEST_RUN_ID").unwrap_or_else(|_| format!("pid-{}", std::process::id()));
+    Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join("preinit-cache")
+        .join(run_id)
+}
+
+/// Delete cache directories left behind by earlier runs.
+///
+/// Each entry is tens of megabytes and nothing else cleans them up. Only
+/// directories older than an hour are touched, so a concurrent run's cache is
+/// never pulled out from under it. Best-effort: failures are irrelevant to the
+/// tests.
+fn prune_stale_caches(current: &Path) {
+    const MAX_AGE: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+    let Some(root) = current.parent() else { return };
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == current {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .and_then(|m| m.elapsed().map_err(std::io::Error::other))
+            .is_ok_and(|age| age > MAX_AGE);
+        if stale {
+            let _ = std::fs::remove_dir_all(&path);
+        }
+    }
+}
+
+/// Pre-initialize once per test run and share the resulting bytes.
+///
+/// Callers passing different `imports` get their own entry, since those produce
+/// genuinely different components.
+async fn shared_preinit(stdlib: &Path, imports: &[&str]) -> Arc<Vec<u8>> {
+    let key = cache_key(imports);
+
+    let cache = PREINIT_CACHE
+        .get_or_init(|| async { Mutex::new(HashMap::new()) })
+        .await;
+    let mut cache = cache.lock().await;
+    if let Some(bytes) = cache.get(&key) {
+        return Arc::clone(bytes);
+    }
+
+    let dir = cache_dir();
+    let path = dir.join(format!("{key}.wasm"));
+
+    let bytes = if let Ok(bytes) = std::fs::read(&path) {
+        Arc::new(bytes)
+    } else {
+        let bytes = Arc::new(
+            pre_initialize(stdlib, None, imports, &[])
+                .await
+                .expect("pre-initialization should succeed"),
+        );
+
+        // Publish via rename so a concurrent reader never sees a partial file.
+        // Two processes racing here just both do the work, which is no worse
+        // than not caching at all.
+        std::fs::create_dir_all(&dir).expect("cache directory should be creatable");
+        prune_stale_caches(&dir);
+        let tmp = dir.join(format!("{key}.{}.tmp", std::process::id()));
+        std::fs::write(&tmp, bytes.as_slice()).expect("cache entry should be writable");
+        std::fs::rename(&tmp, &path).expect("cache entry should be publishable");
+
+        bytes
+    };
+
+    cache.insert(key, Arc::clone(&bytes));
+    bytes
 }
 
 // =============================================================================
@@ -31,9 +154,7 @@ async fn preinit_basic() {
     let stdlib = get_stdlib_path();
 
     // Pre-initialize with no imports
-    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     // Verify we got valid component bytes
     assert!(!preinit_bytes.is_empty());
@@ -46,13 +167,11 @@ async fn preinit_basic() {
 async fn preinit_can_execute() {
     let stdlib = get_stdlib_path();
 
-    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     // Create sandbox from pre-initialized bytes
     let sandbox = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes)
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .expect("sandbox creation should succeed");
@@ -74,12 +193,10 @@ async fn preinit_arbitrary_imports_work() {
     let stdlib = get_stdlib_path();
 
     // Pre-initialize with NO imports (empty list)
-    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     let sandbox = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes)
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .expect("sandbox creation should succeed");
@@ -117,11 +234,7 @@ print(f"collections: {type(collections.OrderedDict()).__name__}")
 async fn preinit_multiple_sandboxes() {
     let stdlib = get_stdlib_path();
 
-    let preinit_bytes = Arc::new(
-        pre_initialize(&stdlib, None, &[], &[])
-            .await
-            .expect("pre-initialization should succeed"),
-    );
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     // Create multiple sandboxes from the same pre-init bytes
     for i in 0..3 {
@@ -145,13 +258,11 @@ async fn preinit_multiple_sandboxes() {
 async fn preinit_sandboxes_isolated() {
     let stdlib = get_stdlib_path();
 
-    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     // Create first sandbox and set a variable
     let sandbox1 = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes.clone())
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .unwrap();
@@ -163,7 +274,7 @@ async fn preinit_sandboxes_isolated() {
 
     // Create second sandbox - should NOT see the variable
     let sandbox2 = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes)
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .unwrap();
@@ -188,13 +299,12 @@ except NameError:
 async fn preinit_with_imports() {
     let stdlib = get_stdlib_path();
 
-    // Pre-initialize with json module imported
-    let preinit_bytes = pre_initialize(&stdlib, None, &["json"], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    // Pre-initialize with json module imported.
+    // This needs its own pre-init: different imports, different component.
+    let preinit_bytes = shared_preinit(&stdlib, &["json"]).await;
 
     let sandbox = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes)
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .expect("sandbox creation should succeed");
@@ -226,12 +336,10 @@ print(json.dumps([1, 2, 3]))
 async fn preinit_imports_work_within_execution() {
     let stdlib = get_stdlib_path();
 
-    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     let sandbox = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes)
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .unwrap();
@@ -258,12 +366,10 @@ print(hashlib.md5(b'test').hexdigest()[:8])
 async fn preinit_file_operations_work() {
     let stdlib = get_stdlib_path();
 
-    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[])
-        .await
-        .expect("pre-initialization should succeed");
+    let preinit_bytes = shared_preinit(&stdlib, &[]).await;
 
     let sandbox = Sandbox::builder()
-        .with_wasm_bytes(preinit_bytes)
+        .with_wasm_bytes((*preinit_bytes).clone())
         .with_python_stdlib(&stdlib)
         .build()
         .unwrap();


### PR DESCRIPTION
Closes #335.

## What was wrong

The eight tests in `crates/eryx/tests/preinit.rs` each called `pre_initialize()` themselves. A single call already saturates several cores (wizer instrumentation plus a full wasmtime compile of a 34MB component), so eight of them running concurrently thrashed each other and the rest of the suite.

From the `main` push run for #331 (job `Test`, 585 tests, 789s wall, 2524 test-seconds total), the preinit group was **the nine slowest tests in the entire run** and ~1200s of those test-seconds:

```
   168.6  eryx::preinit preinit_file_operations_work
   168.4  eryx::preinit preinit_can_execute
   167.8  eryx::preinit preinit_arbitrary_imports_work
   161.0  eryx::preinit preinit_imports_work_within_execution
   156.8  eryx::preinit preinit_multiple_sandboxes
   155.8  eryx::preinit preinit_sandboxes_isolated
   148.2  eryx::preinit preinit_with_imports
   124.1  eryx::vfs_bypass_security test_extreme_offset_attack
    82.4  eryx::preinit preinit_basic
    29.4  eryx-wasm-runtime::runtime_test test_instantiate_component   <- next slowest, 5x smaller
```

against the profile's 180s kill threshold (`slow-timeout` 60s x `terminate-after` 3).

## Why the fix in the issue doesn't work as written

The issue suggests a `tokio::sync::OnceCell` static. **nextest runs each test in its own process**, so a static shares nothing under it — verified locally with two tests printing their pid and a shared `AtomicUsize`: different pids, both seeing count 0. It would only help under plain `cargo test`.

## What this does

- Caches the pre-initialized bytes **on disk** under `CARGO_TARGET_TMPDIR`, keyed by `NEXTEST_RUN_ID` — one id shared by every test process in a run, so entries are always fresh with respect to the runtime that produced them. A stale entry would silently test the wrong component, which is why the key is per-run rather than content-hashed. Falls back to a pid key (plus an in-process map) under plain `cargo test`.
- `preinit_with_imports` passes `&["json"]`, so imports are part of the cache key and it keeps its own entry — the caveat noted in the issue.
- Publishes via temp-file + rename, so a reader never sees a partial file. Two processes racing just both do the work, which is no worse than not caching.
- Prunes cache directories from runs older than an hour; each entry is ~22MB and nothing else cleans them up.
- Adds a nextest `[test-groups]` entry capping `eryx::preinit` at one thread. This is what makes the cache effective (the first test computes, the rest read) *and* removes the self-contention. The override lives on `profile.default` so `ci` inherits it — confirmed with `cargo nextest show-config test-groups --profile ci`.

## Measured locally (32 cores, same toolchain, `--profile ci`)

| | wall | user CPU |
|---|---|---|
| before | 33.6s (8 concurrent) | **801s** |
| after | 45.6s (serialized) | **519s** |

35% less CPU. Wall clock rises locally only because the group is now serialized on one thread — on a CPU-bound 4-core runner that trade is the right way round, and the group no longer competes with itself. `preinit_basic` now runs in 0.008s off the cache.

The remaining cost is the per-test sandbox compile (`with_wasm_bytes` compiles the component; the Tier-2 component cache is only wired up for the native-extensions path), which each test genuinely needs.

## Also

Dropped `profile.ci.default-timeout = "120s"`. nextest has no such key — it was being silently ignored with a warning on every run:

```
warning: in config file .config/nextest.toml, ignoring unknown configuration key: profile.ci.default-timeout
```

So the effective per-test limit has always been `slow-timeout` x `terminate-after` = 180s, not 120s. No behaviour change, just removes the misleading config and the warning.

Per the issue's last question, `retries = 2` and `fail-fast = true` are left alone — worth a separate discussion now that the underlying waste is gone.

## Verification

- `cargo nextest run -p eryx --features preinit -E 'test(/^preinit/)' --profile ci` — 8 passed, one pre-init per arg set (cache dir contains exactly `default.wasm` and `imports-json.wasm`)
- `cargo test -p eryx --features preinit --test preinit` — 8 passed, exercises the in-process path
- `cargo clippy -p eryx --features preinit --tests -- -D warnings`, `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)