### PR TITLE
docs(net): don't link private MAX_READ_LEN from public docs

### DIFF
--- a/crates/eryx/src/net.rs
+++ b/crates/eryx/src/net.rs
@@ -548,8 +548,8 @@ impl ConnectionManager {
     /// `timeout_ms` is the guest-requested I/O timeout in milliseconds
     /// (`0` = use the host default); see `effective_timeout`.
     ///
-    /// `len` is capped at [`MAX_READ_LEN`]; like any socket read, this may
-    /// return fewer bytes than requested.
+    /// `len` is capped at 1 MiB; like any socket read, this may return fewer
+    /// bytes than requested.
     pub async fn tcp_read(
         &mut self,
         handle: u32,
@@ -783,8 +783,8 @@ impl ConnectionManager {
     /// `timeout_ms` is the guest-requested I/O timeout in milliseconds
     /// (`0` = use the host default); see `effective_timeout`.
     ///
-    /// `len` is capped at [`MAX_READ_LEN`]; like any socket read, this may
-    /// return fewer bytes than requested.
+    /// `len` is capped at 1 MiB; like any socket read, this may return fewer
+    /// bytes than requested.
     pub async fn tls_read(
         &mut self,
         handle: u32,


### PR DESCRIPTION
Fixes the `Documentation` and `docs.rs` jobs on `main`, which I broke in f4e3979:

```
error: public documentation for `tcp_read` links to private item `MAX_READ_LEN`
   --> crates/eryx/src/net.rs:551:30
error: public documentation for `tls_read` links to private item `MAX_READ_LEN`
   --> crates/eryx/src/net.rs:786:30
error: could not document `eryx`
```

`MAX_READ_LEN` is private, so an intra-doc link to it from a public method trips rustdoc's `private_intra_doc_links`, which `RUSTDOCFLAGS=-D warnings` promotes to an error. State the value in prose instead — readers of the public API care that the cap is 1 MiB, not what the constant is called.

Everything else on that run passed (Test, Book Tests, Lint, Examples, Python Bindings, Feature Combinations, MSRV, macOS/Windows checks); these two doc jobs were the only failures.

Verified with the exact CI invocation, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, which now completes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)