### PR TITLE
ci: install mold without apt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,26 +279,26 @@ jobs:
           version: "35.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # `apt-daily`/`unattended-upgrades` runs on freshly booted runners and
-      # holds the dpkg/apt locks. apt waits for a held lock *forever* by
-      # default and prints nothing while it does, so a run that loses this race
-      # burns the full 6h job limit with no output — that is what hung Lint and
-      # Documentation on #256. DPkg::Lock::Timeout bounds the lock wait (apt
-      # then exits non-zero, so the failure is fast and retryable) and
-      # timeout-minutes is the backstop for anything else that stalls, such as
-      # an unresponsive archive mirror.
-      - name: Install mold linker and clang
-        timeout-minutes: 5
-        run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y mold clang
+      # No apt anywhere in this workflow, deliberately. Beyond the dpkg-lock
+      # hang that took protoc off apt in #337, `azure.archive.ubuntu.com` is
+      # slow often enough to matter: on #339 `apt-get update` pulled 11.4 MB of
+      # package indexes at 47 kB/s, taking 4m01s, then spent another 38s and
+      # four `Ign:` retries fetching mold before falling back to
+      # archive.ubuntu.com — 4m51s against this step's 5m timeout, for a 2.5 MB
+      # linker. setup-mold fetches a prebuilt release from GitHub instead, the
+      # same trade as arduino/setup-protoc above.
+      #
+      # Nothing else was needed from apt: the runner image already ships clang
+      # and gcc, and `-fuse-ld=mold` works with the default gcc driver, so no
+      # `linker =` override is required either.
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Configure mold linker
         run: |
           mkdir -p .cargo
           cat >> .cargo/config.toml << 'EOF'
           [target.x86_64-unknown-linux-gnu]
-          linker = "clang"
           rustflags = ["-C", "link-arg=-fuse-ld=mold"]
           EOF
 


### PR DESCRIPTION
The Test job's remaining apt call took **4m51s** on #339 — 9 seconds short of its own 5-minute timeout. From that job's log:

```
Fetched 11.4 MB in 4min 1s (47.2 kB/s)          # apt-get update, package indexes
...
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 mold amd64 2.30.0+dfsg-1build1   (x4)
Get:3 https://archive.ubuntu.com/ubuntu noble/universe amd64 mold amd64 2.30.0+dfsg-1build1 [2529 kB]
Fetched 2535 kB in 38s (67.3 kB/s)
```

This isn't the dpkg-lock hang from #337 — that guard works. It's `azure.archive.ubuntu.com` being slow at 47 kB/s, plus four `Ign:` retries before falling back to `archive.ubuntu.com`. Everything else in the same run was fast (artifact download, protoc, the GitHub-hosted actions), so it's specific to the apt mirror.

Two details make it worse than it looks:

- **The only real download was mold, at 2.5 MB.** `clang`'s deb was 5,846 bytes — the meta-package. clang-18 is already in the runner image, which is why `apt-get install` reported "0 upgraded, 2 newly installed" and needed only 2,535 kB total.
- **So the 4 minutes went almost entirely on package indexes** that nothing else in the job uses, in order to install a 2.5 MB linker.

Fetch mold from its GitHub release via `setup-mold` instead — the same trade #337 made for protoc. There is now no apt call anywhere in this workflow.

Also drops `linker = "clang"` from the generated `.cargo/config.toml`: `-fuse-ld=mold` works with the default gcc driver (image has gcc 13; GCC has supported `-fuse-ld=mold` since 12), so the clang install was never load-bearing. Not depending on whether bare `clang` resolves on PATH is one less thing to break on a runner-image update.

**On bigger runners:** they wouldn't have helped. Larger GitHub-hosted runners sit on the same Azure network and use the same Ubuntu mirror — you'd pay more for the same 47 kB/s. The fix is to stop needing the mirror.

The proof is this PR's own Test job: watch the "Install mold linker" step, and check the build still links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)