### PR TITLE
fix(macros): unbreak publishing by dropping the dev-dep version req

### DIFF
--- a/crates/eryx-macros/Cargo.toml
+++ b/crates/eryx-macros/Cargo.toml
@@ -19,7 +19,14 @@ quote = "1"
 syn = { version = "3", features = ["full", "parsing", "extra-traits"] }
 
 [dev-dependencies]
-eryx = { workspace = true, features = ["macros", "native-extensions", "vfs"] } #unified
+# Must stay a path dependency with NO version requirement, and must not be
+# unified into [workspace.dependencies]: this is a cycle (eryx depends on
+# eryx-macros for its `macros` feature), and cargo only tolerates a cyclic
+# dev-dependency if it can drop it when packaging, which it does exactly when no
+# version is specified. With a version, publishing eryx-macros has to resolve
+# `eryx` from the registry at a version that does not exist yet, because eryx is
+# published after it. That is what broke the v0.6.0 release.
+eryx = { path = "../eryx", features = ["macros", "native-extensions", "vfs"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
The v0.6.0 release failed on its first package ([run](https://github.com/eryx-org/eryx/actions/runs/32277300063/job/96147626943)):

```
failed to publish eryx-macros:
  Packaging eryx-macros v0.6.0
  error: failed to prepare local package for uploading
    failed to select a version for the requirement `eryx = "^0.6.0"`
```

Nothing was published and no tags were pushed — it died on the first crate, so the release simply didn't happen. All five crates are still at 0.5.0 in the index.

## Why

`eryx-macros` dev-depends on `eryx` (to test the macro it generates), and `eryx` depends on `eryx-macros` for its `macros` feature. That's a cycle, and cargo only tolerates a cyclic dev-dependency because it **drops dev-dependencies when packaging** — which it does exactly when no version is specified. Give one a version requirement and publishing has to resolve it from the registry, which can't work here: `eryx-macros` is published *before* `eryx`, so `eryx 0.6.0` doesn't exist yet.

The version requirement arrived in #309, which unified the dep into `[workspace.dependencies]`:

```diff
-eryx = { path = "../eryx", features = ["macros", "native-extensions", "vfs"] }
+eryx = { workspace = true, features = ["macros", "native-extensions", "vfs"] } #unified
```

and the workspace entry is `eryx = { path = "crates/eryx", version = "^0.6.0" }`. No release happened between 2026-08-12 and today, so it stayed dormant. v0.5.0 published fine on 2026-06-16 with the path-only form.

## Fix

Restore the path-only dev-dep, with a comment saying why — otherwise the next `cargo rail unify` run re-applies it and the next release breaks the same way.

## Verification

- `cargo rail unify --check` is clean: `Member edits: 0`, "no unification opportunities found". So rail 0.21 doesn't actually demand this unification and no `.config/rail.toml` change is needed.
- `cargo publish --dry-run -p eryx-macros` now gets all the way to `Uploading` / `aborting upload due to dry run`, and the verify build compiles `eryx-macros` alone — confirming the dev-dep really is dropped from the packaged manifest.
- Checked every other crate for the same latent pattern; `eryx-macros` is the only one with a sibling dev-dep.

Merging this re-triggers release-plz, which should then release 0.6.0 for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)