### PR TITLE
ci: stop release workflows firing on every crate's tag

### DIFF
--- a/.github/workflows/eryx-precompile-release.yml
+++ b/.github/workflows/eryx-precompile-release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'eryx-precompile**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -31,10 +31,17 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest
-    # Only run for the main eryx crate release (not eryx-macros, eryx-vfs, etc.)
+    # Only run for the main eryx crate release, not the other crates.
+    #
+    # `startsWith(tag, 'eryx-v')` alone is NOT enough: release-plz tags are
+    # `{crate}-v{version}`, and "eryx-vfs-v0.6.0" starts with "eryx-v" too, so
+    # eryx-vfs releases were also triggering this. The other crates happen not to
+    # collide (eryx-macros, eryx-precompile, eryx-runtime), but any future crate
+    # whose name starts with "v" after the dash would need excluding here as well.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'eryx-v')
+      (startsWith(github.event.release.tag_name, 'eryx-v') &&
+       !startsWith(github.event.release.tag_name, 'eryx-vfs-v'))
     steps:
       - name: Free disk space
         run: |

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -30,10 +30,17 @@ jobs:
   build-runtime:
     name: Build Runtime
     runs-on: ubuntu-latest
-    # Only run for the main eryx crate release (not eryx-macros, eryx-vfs, etc.)
+    # Only run for the main eryx crate release, not the other crates.
+    #
+    # `startsWith(tag, 'eryx-v')` alone is NOT enough: release-plz tags are
+    # `{crate}-v{version}`, and "eryx-vfs-v0.6.0" starts with "eryx-v" too, so
+    # eryx-vfs releases were also triggering this. The other crates happen not to
+    # collide (eryx-macros, eryx-precompile, eryx-runtime), but any future crate
+    # whose name starts with "v" after the dash would need excluding here as well.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'eryx-v')
+      (startsWith(github.event.release.tag_name, 'eryx-v') &&
+       !startsWith(github.event.release.tag_name, 'eryx-vfs-v'))
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/upload-runtime.yml
+++ b/.github/workflows/upload-runtime.yml
@@ -1,5 +1,5 @@
-# Upload runtime.wasm to GitHub releases after cargo-dist creates the release
-# This runs separately from the cargo-dist workflow to avoid conflicts
+# Upload runtime.wasm to the main eryx GitHub release.
+# Runs separately from the release workflows to avoid conflicts over the release.
 
 name: Upload Runtime Artifacts
 
@@ -13,6 +13,13 @@ permissions:
 jobs:
   upload-runtime:
     runs-on: ubuntu-24.04
+    # Only the main eryx release gets the runtime asset. Without this the job ran
+    # for all four release-plz releases, rebuilding runtime.wasm each time and
+    # attaching it to releases that have no use for it. See the note in
+    # python-release.yml for why the eryx-vfs exclusion is needed.
+    if: >-
+      startsWith(github.event.release.tag_name, 'eryx-v') &&
+      !startsWith(github.event.release.tag_name, 'eryx-vfs-v')
     steps:
       - uses: actions/checkout@v7
         with:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -11,6 +11,11 @@ ci = "github"
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Only respond to tags for the package dist owns. Without this, dist's generated
+# CI triggers on every version tag in the repo, so the release-plz tags for the
+# library crates (eryx-v*, eryx-vfs-v*, ...) also start a dist run, which then
+# fails trying to `gh release create` a release release-plz has already made.
+tag-namespace = "eryx-precompile"
 # Build packages individually instead of using --workspace
 # This avoids feature unification issues where other packages (like eryx-python)
 # enable features that require build-time artifacts we don't have


### PR DESCRIPTION
The v0.6.0 release pushed five tags (`eryx-v0.6.0`, `eryx-vfs-v0.6.0`, `eryx-runtime-v0.6.0`, `eryx-macros-v0.6.0`, `eryx-precompile-v0.6.0`) and three workflows reacted to more of them than they should.

## cargo-dist `Release` — 2 failed runs

Generated CI triggered on `'**[0-9]+.[0-9]+.[0-9]+*'`, i.e. every version tag. So `eryx-v0.6.0` and `eryx-vfs-v0.6.0` each started a dist run that failed in `host`:

```
gh release create "eryx-v0.6.0" --target "$RELEASE_COMMIT" ... artifacts/*
##[error]Process completed with exit code 1
```

— because release-plz had already created that release. dist owns only `eryx-precompile` (per `dist-workspace.toml` members).

Fixed by setting `tag-namespace = "eryx-precompile"` and regenerating with the pinned dist 0.30.3, rather than hand-editing generated CI so a future `dist generate` keeps it. dist renames the workflow to `eryx-precompile-release.yml` with trigger `'eryx-precompile**[0-9]+.[0-9]+.[0-9]+*'`; the old `release.yml` is removed (shows as a rename in the diff).

## Python Release / JS Release — double-published

Both were guarded with:

```yaml
# Only run for the main eryx crate release (not eryx-macros, eryx-vfs, etc.)
if: startsWith(github.event.release.tag_name, 'eryx-v')
```

The comment says it excludes eryx-vfs. It doesn't: release-plz tags are `{crate}-v{version}`, and **`eryx-vfs-v0.6.0` starts with `eryx-v`**. eryx-macros (`eryx-m`) and eryx-runtime (`eryx-r`) genuinely don't match — eryx-vfs is the one crate whose name continues with `v`, so it slipped through. Both workflows therefore ran twice per release, publishing the same version to PyPI and npm concurrently, with the loser failing on "already exists".

Now excluded explicitly, with a comment recording the trap for whoever adds the next crate.

## Upload Runtime Artifacts — no guard at all

`on: release: [published]` with no condition, so it rebuilt `runtime.wasm` for **all four** releases and attached it to three that have no use for it. Same guard added. Its header comment also still credited cargo-dist with creating releases, which release-plz took over.

## Verification

Evaluated the resulting conditions against all five real tags:

```
tag                        py/js/upload-runtime   dist release
eryx-v0.6.0                True                   False
eryx-vfs-v0.6.0            False                  False
eryx-runtime-v0.6.0        False                  False
eryx-macros-v0.6.0         False                  False
eryx-precompile-v0.6.0     False                  True
```

Exactly one match each. All workflow YAML parses.

Note this can't be fully proven until the next release actually tags — these triggers only fire on `release`/tag events, so CI on this PR exercises the YAML but not the conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)