### PR TITLE
ci: exclude eryx-macros from cargo-rail unification

### DIFF
--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -21,8 +21,19 @@ skip_undeclared_patterns = [
   "*_impl",
 ]
 
-# Exclude eryx-wasm-runtime as it's a staticlib for WASM, not a normal crate
-exclude = ["eryx-wasm-runtime"]
+# eryx-wasm-runtime: a staticlib for WASM, not a normal crate.
+#
+# eryx-macros: its dev-dependency on eryx must stay a bare path dep with no
+# version requirement. eryx depends on eryx-macros for its `macros` feature, so
+# that dev-dep is a cycle, and cargo only tolerates a cyclic dev-dependency
+# because it drops dev-deps when packaging - which it does exactly when no
+# version is given. Unifying it into [workspace.dependencies] attaches
+# `version = "^x.y.z"`, and publishing eryx-macros then has to resolve eryx from
+# the registry at a version that does not exist yet, because eryx is published
+# after it. That is what broke the v0.6.0 release (#344). `include_paths = false`
+# does not prevent this - it still converts the member dep - so the crate has to
+# be excluded from unification outright.
+exclude = ["eryx-wasm-runtime", "eryx-macros"]
 include = []
 max_backups = 3
 msrv_policy = { mode = "compute", source = "workspace" }


### PR DESCRIPTION
Fixes the red `Dependency Check` on main. `cargo rail unify --check` wants to undo #344:

```
changed:
  member edits: 1 across 1 crate(s)
will mutate:
  crates/eryx-macros/Cargo.toml
  [dev-dependencies] eryx -> workspace = true, features = ["macros", "native-extensions", "vfs"]
```

That's precisely the change that broke publishing an hour ago: unifying the dep attaches the workspace entry's `version = "^x.y.z"`, and since `eryx-macros` is published *before* `eryx`, resolving it from the registry can't work. rail would helpfully re-break the next release.

rail has no per-dependency opt-out, and I checked that `include_paths = false` **does not** help — it still converts the member dep. So the crate is excluded from unification, with the reasoning recorded in `.config/rail.toml` so the next person doesn't "tidy" it away.

Cost: rail no longer unifies `eryx-macros`' other dependencies. All four (`schemars`, `serde`, `serde_json`, `tokio`) are already `workspace = true`, so nothing drifts unless someone hand-edits them.

## My mistake in #344

I stated there that `cargo rail unify --check` was clean with 0 member edits. It wasn't. `mise exec -- cargo rail` resolves to `/home/ben/.cargo/bin/cargo-rail` **0.7.0**, which shadows the **0.21.0** that `mise.toml` pins and CI installs — and 0.7.0 doesn't do this unification at all. So I verified against a binary four majors behind CI and reported a false pass.

Verified this time by invoking the pinned binary directly:

```
$ ~/.local/share/mise/installs/cargo-cargo-rail/0.21.0/bin/cargo-rail rail unify --check
status: no changes
exit=0
```

and reproduced main's failure with the same binary first, so the check is genuinely exercising the same code path CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)