### PR TITLE
feat!: add a Baseline CPU feature level and seal CpuFeatureLevel

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -275,6 +275,12 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          # aarch64 has no Cranelift psABI presets, so "baseline" (pin the
+          # target, enable nothing) is the only setting that does not bake this
+          # runner's CPU into the wheel. Without it the default is native, and a
+          # runner refresh to ARMv8.6 hardware would emit has_i8mm and break
+          # every M1. Costs LSE atomics, FP16, dotprod and I8MM.
+          ERYX_CPU_FEATURES: "baseline"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -348,6 +354,12 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          # aarch64 has no Cranelift psABI presets, so "baseline" (pin the
+          # target, enable nothing) is the only setting that does not bake this
+          # runner's CPU into the wheel. Without it the default is native, and a
+          # runner refresh to ARMv8.6 hardware would emit has_i8mm and break
+          # every M1. Costs LSE atomics, FP16, dotprod and I8MM.
+          ERYX_CPU_FEATURES: "baseline"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm
@@ -419,6 +431,12 @@ jobs:
           ls -la crates/eryx-runtime/runtime.cwasm
         env:
           ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          # aarch64 has no Cranelift psABI presets, so "baseline" (pin the
+          # target, enable nothing) is the only setting that does not bake this
+          # runner's CPU into the wheel. Without it the default is native, and a
+          # runner refresh to ARMv8.6 hardware would emit has_i8mm and break
+          # every M1. Costs LSE atomics, FP16, dotprod and I8MM.
+          ERYX_CPU_FEATURES: "baseline"
 
       - name: Mark cwasm as up-to-date
         run: touch crates/eryx-runtime/runtime.cwasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,6 +4683,7 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
  "wit-parser 0.254.0",
@@ -4856,6 +4857,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5273668f321005b9c75532ed073c0f6c3fd1147f3736a544c9e3070c47876489"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.254.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
 ]
 
 [[package]]
@@ -5061,6 +5079,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b223d6350e387101a19062dd25b1c1763b0c28b26b8eeedde2e7568cab1b07c"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.20",
+ "wasmparser 0.254.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+]
 
 [[package]]
 name = "windows"

--- a/crates/eryx-precompile/src/main.rs
+++ b/crates/eryx-precompile/src/main.rs
@@ -102,7 +102,7 @@ struct CompileArgs {
 
     /// CPU feature level for AOT compilation
     ///
-    /// Controls which x86-64 psABI instruction set level the artifact targets.
+    /// Controls which instruction set level the artifact targets.
     /// Lower levels are more portable; higher levels produce faster code.
     ///
     /// Values:
@@ -111,6 +111,7 @@ struct CompileArgs {
     ///   x86-64-v3  - AVX2, FMA, BMI1/2 (~2013+ Haswell, recommended for Fly.io)
     ///   x86-64-v2  - SSE4.2, POPCNT (~2008+ Nehalem)
     ///   x86-64     - Baseline SSE2 (maximum compatibility)
+    ///   baseline   - Target architecture baseline, no optional features
     ///
     /// Defaults to native when omitted.
     #[arg(short = 'c', long, value_name = "LEVEL")]

--- a/crates/eryx-server/Dockerfile
+++ b/crates/eryx-server/Dockerfile
@@ -40,6 +40,9 @@ RUN mkdir -p crates/eryx-wasm-runtime/tests/python-stdlib && \
   --strip-components=0
 
 # Build eryx-precompile and produce runtime.cwasm with preinit.
+# The x86-64-vN levels are x86-64 only; building this image on an arm64
+# host needs --build-arg ERYX_CPU_FEATURES=baseline, which pins the target
+# without enabling optional features (aarch64 has no psABI presets).
 ARG ERYX_CPU_FEATURES=x86-64-v3
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/build/target \

--- a/crates/eryx/Cargo.toml
+++ b/crates/eryx/Cargo.toml
@@ -160,6 +160,9 @@ criterion.workspace = true
 crossterm.workspace = true
 rcgen.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+# `all-arch` pulls in Cranelift's non-host backends so the CPU-feature tests
+# can check aarch64 configuration from an x86 runner (eryx has no ARM test job).
+wasmtime = { workspace = true, features = ["all-arch"] }
 wat = "1"
 
 [lints]

--- a/crates/eryx/examples/precompile.rs
+++ b/crates/eryx/examples/precompile.rs
@@ -34,6 +34,8 @@
 //! - `x86-64-v2` - SSE4.2, POPCNT, SSSE3 (~2008+ CPUs)
 //! - `x86-64-v3` - AVX2, FMA, BMI1/2 (~2013+ CPUs, no AVX-512) - **recommended for Fly.io**
 //! - `x86-64-v4` - AVX-512 (~2017+ CPUs)
+//! - `baseline` - the target's own baseline; use this on aarch64, which has
+//!   no psABI presets and would otherwise inherit the build machine's features
 //! - `native` - Host CPU features (default)
 //!
 //! ## Cross-compilation: Target Triples

--- a/crates/eryx/src/wasm.rs
+++ b/crates/eryx/src/wasm.rs
@@ -411,7 +411,20 @@ impl ExecutionOutput {
 /// )?;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum CpuFeatureLevel {
+    /// The target architecture's own baseline, with no optional CPU features.
+    ///
+    /// Portable to every CPU the target supports, and the only portable choice
+    /// on architectures Cranelift has no psABI presets for — notably aarch64,
+    /// where the alternative is [`Self::Native`] baking in whichever machine
+    /// happened to run the build. On x86-64 this is equivalent to
+    /// [`Self::X86_64`].
+    ///
+    /// The cost is real: on aarch64 it gives up LSE atomics, FP16, dot-product
+    /// and I8MM, so hot code is slower. Use it for artifacts you ship to
+    /// machines you do not control.
+    Baseline,
     /// Baseline x86_64: SSE2 only. Maximum compatibility (~2003+ CPUs).
     X86_64,
     /// x86-64-v2: SSE4.2, POPCNT, SSSE3 (~2008+ CPUs, Nehalem/Westmere era).
@@ -433,6 +446,7 @@ impl CpuFeatureLevel {
     #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
+            "baseline" => Some(Self::Baseline),
             "x86-64" | "x86-64-v1" => Some(Self::X86_64),
             "x86-64-v2" => Some(Self::X86_64v2),
             "x86-64-v3" => Some(Self::X86_64v3),
@@ -446,6 +460,7 @@ impl CpuFeatureLevel {
     #[must_use]
     pub const fn as_str(&self) -> &'static str {
         match self {
+            Self::Baseline => "baseline",
             Self::X86_64 => "x86-64",
             Self::X86_64v2 => "x86-64-v2",
             Self::X86_64v3 => "x86-64-v3",
@@ -467,7 +482,7 @@ impl std::str::FromStr for CpuFeatureLevel {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::parse(s).ok_or_else(|| {
             format!(
-                "Unknown CPU feature level '{}'. Valid values: x86-64, x86-64-v2, x86-64-v3, x86-64-v4, native",
+                "Unknown CPU feature level '{}'. Valid values: baseline, x86-64, x86-64-v2, x86-64-v3, x86-64-v4, native",
                 s
             )
         })
@@ -1936,6 +1951,8 @@ impl PythonExecutor {
     /// # CPU Feature Levels
     ///
     /// Set `ERYX_CPU_FEATURES` to a preset level:
+    /// - `baseline` - The target architecture's baseline, no optional features.
+    ///   The only portable choice on aarch64, which has no psABI presets.
     /// - `x86-64` - Baseline x86_64 (SSE2 only, most compatible)
     /// - `x86-64-v2` - SSE4.2, POPCNT, SSSE3 (Nehalem/Westmere era, ~2008+)
     /// - `x86-64-v3` - AVX2, BMI1/2, FMA (Haswell era, ~2013+, no AVX-512)
@@ -2017,18 +2034,9 @@ impl PythonExecutor {
         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
         config.async_stack_size(512 * 1024);
 
-        // Configure target triple. Doing so also stops Cranelift inferring CPU
-        // features from the build machine, which `apply_cpu_feature_level`
-        // relies on — hence passing whether it already happened here.
-        let target_pinned = target.is_some();
-        if let Some(target_str) = target {
-            config
-                .target(target_str)
-                .map_err(|e| Error::WasmEngine(format!("Invalid target '{target_str}': {e}")))?;
-        }
-
-        // Apply CPU feature level
-        Self::apply_cpu_feature_level(&mut config, cpu_features, target_pinned)?;
+        // Target triple and CPU features are set together: pinning a triple is
+        // also what stops Cranelift inferring features from the build machine.
+        Self::apply_cpu_feature_level(&mut config, cpu_features, target)?;
 
         Engine::new(&config).map_err(|e| Error::WasmEngine(e.to_string()))
     }
@@ -2062,33 +2070,70 @@ impl PythonExecutor {
     /// cost of not knowing about it is a missed optimisation rather than an
     /// artifact that refuses to load.
     ///
-    /// `target_pinned` records whether the caller already set an explicit
-    /// target, in which case inference is off already and only the preset is
-    /// needed.
+    /// [`CpuFeatureLevel::Baseline`] pins the target and stops there, which is
+    /// the only portable option on architectures Cranelift has no presets for.
+    /// The psABI levels are x86-64 only, so asking for one against a non-x86-64
+    /// target is rejected here rather than surfacing as an unknown-setting error
+    /// from `Engine::new`.
+    ///
+    /// `explicit_target` is the caller's requested triple, if any; the host's is
+    /// used otherwise.
     #[cfg(any(feature = "embedded", feature = "preinit"))]
     #[allow(unsafe_code)]
     fn apply_cpu_feature_level(
         config: &mut Config,
         level: CpuFeatureLevel,
-        target_pinned: bool,
+        explicit_target: Option<&str>,
     ) -> std::result::Result<(), Error> {
-        // `Native` means "whatever this machine has", which is precisely what
-        // Cranelift does when no target is pinned. Leave it alone.
+        // `Native` means "whatever this machine has", which is exactly what
+        // Cranelift does when no target is pinned — including when the caller
+        // asked for a specific triple, where it is the caller's business.
         if level == CpuFeatureLevel::Native {
+            if let Some(target_str) = explicit_target {
+                config.target(target_str).map_err(|e| {
+                    Error::WasmEngine(format!("Invalid target '{target_str}': {e}"))
+                })?;
+            }
             return Ok(());
         }
 
-        if !target_pinned {
-            let host = target_lexicon::Triple::host().to_string();
-            config.target(&host).map_err(|e| {
-                Error::WasmEngine(format!("Failed to pin host target '{host}': {e}"))
-            })?;
+        let triple = match explicit_target {
+            Some(target_str) => {
+                config.target(target_str).map_err(|e| {
+                    Error::WasmEngine(format!("Invalid target '{target_str}': {e}"))
+                })?;
+                target_str
+                    .parse::<target_lexicon::Triple>()
+                    .map_err(|e| Error::WasmEngine(format!("Invalid target '{target_str}': {e}")))?
+            }
+            None => {
+                let host = target_lexicon::Triple::host();
+                config.target(&host.to_string()).map_err(|e| {
+                    Error::WasmEngine(format!("Failed to pin host target '{host}': {e}"))
+                })?;
+                host
+            }
+        };
+
+        // The target is pinned now, so Cranelift starts from its baseline and
+        // never consults the build machine. `Baseline` wants exactly that and
+        // nothing more.
+        if level == CpuFeatureLevel::Baseline {
+            return Ok(());
         }
 
-        // SAFETY: `as_str` only ever yields one of Cranelift's x86 psABI preset
-        // names. Engine::new reports an error if the target has no such preset,
-        // which is what happens if an x86-64 level is asked for on another
-        // architecture.
+        // Everything else is an x86-64 psABI level. Cranelift only defines those
+        // presets for x86, so reject other architectures with something more
+        // useful than "unknown setting" out of Engine::new.
+        if triple.architecture != target_lexicon::Architecture::X86_64 {
+            return Err(Error::WasmEngine(format!(
+                "CPU feature level '{level}' is an x86-64 psABI level and does not \
+                 apply to target '{triple}'. Use 'baseline' for a portable build \
+                 or 'native' to use this machine's features."
+            )));
+        }
+
+        // SAFETY: `as_str` yields one of Cranelift's x86 psABI preset names.
         unsafe {
             config.cranelift_flag_enable(level.as_str());
         }
@@ -2109,7 +2154,7 @@ impl PythonExecutor {
             let level: CpuFeatureLevel = level.parse().map_err(Error::WasmEngine)?;
             // No explicit target here: this is the default engine path, so the
             // helper pins the host triple itself.
-            Self::apply_cpu_feature_level(config, level, false)?;
+            Self::apply_cpu_feature_level(config, level, None)?;
         }
 
         // Apply custom Cranelift flags from environment variable.

--- a/crates/eryx/tests/cpu_feature_portability.rs
+++ b/crates/eryx/tests/cpu_feature_portability.rs
@@ -22,6 +22,7 @@ use wasmtime::{Config, Engine};
 
 /// Every psABI level, i.e. everything except `Native`.
 const PINNED_LEVELS: &[CpuFeatureLevel] = &[
+    CpuFeatureLevel::Baseline,
     CpuFeatureLevel::X86_64,
     CpuFeatureLevel::X86_64v2,
     CpuFeatureLevel::X86_64v3,
@@ -56,9 +57,13 @@ fn reference_config(level: CpuFeatureLevel) -> Config {
     config
         .target(&target_lexicon::Triple::host().to_string())
         .expect("the host triple should be a valid target");
-    // SAFETY: `as_str` yields a Cranelift x86 psABI preset name.
-    unsafe {
-        config.cranelift_flag_enable(level.as_str());
+    // `Baseline` is the pinned target with nothing enabled on top; every other
+    // level names a Cranelift x86 psABI preset.
+    if level != CpuFeatureLevel::Baseline {
+        // SAFETY: `as_str` yields a Cranelift x86 psABI preset name.
+        unsafe {
+            config.cranelift_flag_enable(level.as_str());
+        }
     }
     config
 }
@@ -186,4 +191,122 @@ fn native_is_not_pinned_to_a_level() {
         "native output matched every pinned level, which suggests host feature \
          inference is no longer happening for CpuFeatureLevel::Native"
     );
+}
+
+/// The aarch64 story, checked from x86 via cross-compilation.
+///
+/// aarch64 has `has_lse`, `has_pauth`, `has_fp16`, `has_dotprod` and `has_i8mm`
+/// and *no* Cranelift psABI presets, so `Baseline` — pin the triple, enable
+/// nothing — is the only way to get an artifact that does not depend on the
+/// build machine. Without it, wheels built on an M2-or-later runner bake in
+/// ARMv8.6 features (`has_i8mm` especially) and fail to load on an M1.
+///
+/// eryx has no ARM test job, so these run on x86 against an explicit aarch64
+/// target. That needs Cranelift's non-host backends, hence wasmtime's
+/// `all-arch` feature in dev-dependencies.
+mod aarch64 {
+    use super::{Config, CpuFeatureLevel, Engine, PythonExecutor, tiny_component};
+
+    const TARGET: &str = "aarch64-unknown-linux-gnu";
+
+    /// Feature flags Cranelift can infer for aarch64.
+    const ARM_FEATURES: &[&str] = &[
+        "has_lse",
+        "has_pauth",
+        "has_fp16",
+        "has_dotprod",
+        "has_i8mm",
+    ];
+
+    fn pinned_config() -> Config {
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+        config.wasm_component_model_async(true);
+        config.epoch_interruption(true);
+        config.consume_fuel(true);
+        config.memory_init_cow(true);
+        config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
+        config.async_stack_size(512 * 1024);
+        config
+            .target(TARGET)
+            .expect("aarch64 should be a valid target");
+        config
+    }
+
+    /// `Baseline` against an aarch64 target must enable none of the ARM features.
+    ///
+    /// Forcing them all off has to make no difference; if it does, something is
+    /// switching them on from the build machine.
+    #[test]
+    fn baseline_enables_no_arm_features() {
+        let wasm = tiny_component();
+
+        let baseline =
+            PythonExecutor::precompile_with_options(&wasm, Some(TARGET), CpuFeatureLevel::Baseline)
+                .expect("aarch64 baseline precompile should succeed");
+
+        let mut forced = pinned_config();
+        // SAFETY: all are Cranelift aarch64 flag names.
+        unsafe {
+            for flag in ARM_FEATURES {
+                forced.cranelift_flag_set(flag, "false");
+            }
+        }
+        let forced = Engine::new(&forced)
+            .expect("engine with ARM features forced off should build")
+            .precompile_component(&wasm)
+            .expect("forced precompile should succeed");
+
+        assert!(
+            baseline == forced,
+            "aarch64 Baseline differs from an explicitly feature-free build \
+             ({} vs {} bytes), so ARM features are leaking in",
+            baseline.len(),
+            forced.len()
+        );
+    }
+
+    /// Guards that the assertion above is not vacuous: the ARM flags must
+    /// actually reach codegen, so turning one on has to change the output.
+    #[test]
+    fn arm_features_reach_codegen() {
+        let wasm = tiny_component();
+
+        let baseline =
+            PythonExecutor::precompile_with_options(&wasm, Some(TARGET), CpuFeatureLevel::Baseline)
+                .expect("aarch64 baseline precompile should succeed");
+
+        let mut with_lse = pinned_config();
+        // SAFETY: `has_lse` is a Cranelift aarch64 flag name.
+        unsafe {
+            with_lse.cranelift_flag_set("has_lse", "true");
+        }
+        let with_lse = Engine::new(&with_lse)
+            .expect("engine with has_lse should build")
+            .precompile_component(&wasm)
+            .expect("has_lse precompile should succeed");
+
+        assert!(
+            baseline != with_lse,
+            "enabling has_lse did not change the aarch64 output, so this test \
+             cannot detect a leak"
+        );
+    }
+
+    /// An x86-64 psABI level against an aarch64 target must be rejected with a
+    /// clear message rather than an unknown-setting error out of `Engine::new`.
+    #[test]
+    fn x86_levels_are_rejected_for_aarch64() {
+        let wasm = tiny_component();
+
+        let err =
+            PythonExecutor::precompile_with_options(&wasm, Some(TARGET), CpuFeatureLevel::X86_64v2)
+                .expect_err("an x86-64 level should not apply to an aarch64 target");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("x86-64 psABI level") && msg.contains("baseline"),
+            "error should explain the mismatch and point at 'baseline', got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
**Draft, and stacked on #360** — base is `fix/pin-cpu-feature-target`, so review that one first. Retarget to `main` once it lands. Held for the next breaking release.

## Why

#360 stopped CPU features leaking from the build host by pinning the compilation target and applying cranelift's psABI presets. Those presets only exist for x86-64. aarch64 has `has_lse`, `has_pauth`, `has_fp16`, `has_dotprod`, `has_i8mm` and **no presets**, so `Native` was the only usable level there.

And all three aarch64 wheel jobs set no level at all, so they were on `Native`:

| job | runner | level |
|---|---|---|
| `linux-aarch64` | `ubuntu-24.04-arm` | none → Native |
| `musllinux-aarch64` | `ubuntu-24.04-arm` | none → Native |
| `macos-aarch64` | `macos-26` | none → Native |

The threshold that matters is **M2, not M4**: `has_i8mm` is ARMv8.6-A, which M1 (ARMv8.5) lacks. So a runner-image refresh to ARMv8.6 hardware silently emits `has_i8mm` and no M1 can load the wheel — with no CI signal, because every ARM job both produces and consumes on the same runner class.

## What

`CpuFeatureLevel::Baseline` pins the target and enables nothing on top. No flag list, works on any architecture, and preserves #360's property that an unrecognised future flag defaults to off.

It isn't free — on aarch64 it gives up LSE atomics, FP16, dot-product and I8MM, so hot code is slower. It's therefore opt-in, and set for the three aarch64 wheel jobs, where portability is the entire point. **If you'd rather trade portability for speed there, that's the one line to revert.**

Also: requesting an x86-64 level against a non-x86-64 target now returns a message naming `baseline`, instead of a cryptic unknown-setting error from `Engine::new`.

## Breaking

- `CpuFeatureLevel` becomes `#[non_exhaustive]` — downstream exhaustive matches need a wildcard arm. Nothing in the workspace was affected.
- The new `Baseline` variant. On x86-64 it's equivalent to `X86_64`.

## Testing

eryx has no ARM test job (`platform-check` runs `cargo check` on macos-latest, never the suite), so the aarch64 tests **cross-compile from x86**. That needs cranelift's non-host backends, hence wasmtime's `all-arch` in dev-dependencies.

- `baseline_enables_no_arm_features` — forcing all five ARM flags off must make no difference to a `Baseline` aarch64 build.
- `arm_features_reach_codegen` — keeps the above honest: turning `has_lse` on *must* change the output, so the assertion isn't vacuous.
- `x86_levels_are_rejected_for_aarch64` — the new error fires and points at `baseline`.

`Baseline` also joins the existing byte-equality guard from #360. All 7 tests pass; verified `baseline` and `x86-64-v2` both precompile the real runtime and produce different artifacts.

## Not included

The Docker image is single-arch (no `platforms:` anywhere) and already explicit at `x86-64-v3`, so it needs no change — just a comment noting that an arm64 host wants `--build-arg ERYX_CPU_FEATURES=baseline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)