### PR TITLE
feat: add factory-backed Python sessions

### DIFF
--- a/crates/eryx-python/README.md
+++ b/crates/eryx-python/README.md
@@ -459,6 +459,11 @@ from jinja2 import Template
 print(Template("Hello {{ name }}").render(name="World"))
 ''')
 
+# Persistent state with the same preinitialized packages
+session = factory.create_session()
+session.execute("counter = 1")
+session.execute("print(counter)")
+
 # Create many sandboxes from the same factory
 for i in range(100):
     sandbox = factory.create_sandbox()
@@ -482,9 +487,16 @@ sandbox = factory.create_sandbox()
 
 - `factory.size_bytes` - Size of the pre-compiled factory in bytes
 - `factory.create_sandbox(resource_limits=...)` - Create a new sandbox
+- `factory.create_session(...)` - Create a persistent session from the factory
 - `factory.save(path)` - Save factory to a file
 - `factory.to_bytes()` - Get factory as bytes
 - `SandboxFactory.load(path)` - Load factory from a file
+
+Factory sessions default to no execution-time, memory, or fuel limit, with a
+10-second callback timeout and a maximum of 1000 callback invocations. A
+caller-provided `VfsStorage` retains its own quota; `max_vfs_bytes` applies to
+storage created internally for the session. Extracted package storage is kept
+alive by each session, so imports continue to work after dropping the factory.
 
 ### `Session`
 

--- a/crates/eryx-python/python/eryx/_eryx.pyi
+++ b/crates/eryx-python/python/eryx/_eryx.pyi
@@ -724,6 +724,40 @@ class SandboxFactory:
         """
         ...
 
+    def create_session(
+        self,
+        *,
+        vfs: Optional[VfsStorage] = None,
+        vfs_mount_path: Optional[str] = None,
+        resource_limits: Optional[ResourceLimits] = None,
+        network: Optional[NetConfig] = None,
+        callbacks: Optional[Union[CallbackRegistry, Sequence[CallbackDict]]] = None,
+        volumes: Optional[Sequence[tuple[str, str, bool]]] = None,
+        on_stdout: Optional[Callable[[str], None]] = None,
+        on_stderr: Optional[Callable[[str], None]] = None,
+        result_variable: Optional[str] = None,
+    ) -> Session:
+        """Create a persistent session from this factory's preinitialized runtime.
+
+        The session preserves interpreter and module state across executions,
+        while remaining isolated from other sessions and sandboxes. The factory
+        can be dropped after creation; extracted package storage remains owned
+        by the session.
+
+        `vfs_mount_path` applies only when caller-provided `vfs` storage or
+        `volumes` enable a wrapper-visible VFS; by itself it does not expose
+        `Session.vfs`. Caller-provided `vfs` retains its own policy and quota.
+
+        Supported options include VFS storage and mounts, resource limits,
+        networking, callbacks, volumes, output handlers, and a result variable.
+        Defaults are no execution, memory, or fuel limit, a 10-second callback
+        timeout, and 1000 callback invocations.
+
+        Returns a persistent `Session`. Raises `InitializationError` if it
+        cannot be initialized.
+        """
+        ...
+
     def create_sandbox(
         self,
         *,

--- a/crates/eryx-python/src/preinit.rs
+++ b/crates/eryx-python/src/preinit.rs
@@ -4,6 +4,7 @@
 //! The factory bundles packages and pre-imports into a reusable snapshot.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
@@ -13,6 +14,7 @@ use crate::error::{InitializationError, eryx_error_to_py};
 use crate::net_config::NetConfig;
 use crate::resource_limits::ResourceLimits;
 use crate::sandbox::{PyOutputHandler, Sandbox, apply_secrets};
+use crate::session::Session;
 
 /// A factory for creating sandboxes with custom packages.
 ///
@@ -49,7 +51,7 @@ pub struct SandboxFactory {
     site_packages_path: Option<PathBuf>,
     /// Extracted packages (kept alive to prevent temp dir cleanup).
     #[allow(dead_code)]
-    extracted_packages: Vec<eryx::ExtractedPackage>,
+    extracted_packages: Arc<Vec<eryx::ExtractedPackage>>,
 }
 
 /// Construct a pre-compiled artifact with optional content-safe caching.
@@ -143,7 +145,7 @@ impl SandboxFactory {
             precompiled,
             stdlib_path,
             site_packages_path: final_site_packages,
-            extracted_packages,
+            extracted_packages: Arc::new(extracted_packages),
         })
     }
 
@@ -187,7 +189,7 @@ impl SandboxFactory {
             precompiled,
             stdlib_path,
             site_packages_path: site_packages,
-            extracted_packages: Vec::new(),
+            extracted_packages: Arc::new(Vec::new()),
         })
     }
 
@@ -213,6 +215,103 @@ impl SandboxFactory {
             ))
         })?;
         Ok(())
+    }
+
+    /// Create a persistent Python session from this factory's preinitialized
+    /// runtime. The session preserves interpreter and module state across
+    /// executions while remaining isolated from other sessions and sandboxes.
+    /// The factory remains disposable; extracted package ownership is retained
+    /// by the returned session.
+    ///
+    /// Args:
+    ///     vfs: Optional caller-owned VFS storage. Its policy and quota remain
+    ///         owned by the caller.
+    ///     vfs_mount_path: Mount path used when `vfs` or `volumes` enable a
+    ///         wrapper-visible VFS; alone it does not expose `Session.vfs`.
+    ///     resource_limits: Optional session limits. Factory defaults are no
+    ///         execution, memory, or fuel limit, a 10-second callback timeout,
+    ///         and 1000 callback invocations.
+    ///     network: Optional network configuration.
+    ///     callbacks: Optional callbacks that sandboxed code can invoke.
+    ///     volumes: Optional host volume mounts; these enable wrapper-visible
+    ///         VFS storage when no caller storage is supplied.
+    ///     on_stdout: Optional stdout streaming callback.
+    ///     on_stderr: Optional stderr streaming callback.
+    ///     result_variable: Optional variable whose value is returned by execute.
+    ///
+    /// Returns:
+    ///     A new persistent `Session`.
+    ///
+    /// Raises:
+    ///     InitializationError: If the session cannot be initialized.
+    #[pyo3(signature = (*, vfs=None, vfs_mount_path=None, resource_limits=None, network=None, callbacks=None, volumes=None, on_stdout=None, on_stderr=None, result_variable=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn create_session(
+        &self,
+        py: Python<'_>,
+        vfs: Option<crate::vfs::VfsStorage>,
+        vfs_mount_path: Option<String>,
+        resource_limits: Option<ResourceLimits>,
+        network: Option<NetConfig>,
+        callbacks: Option<Bound<'_, PyAny>>,
+        volumes: Option<Vec<(String, String, bool)>>,
+        on_stdout: Option<Py<PyAny>>,
+        on_stderr: Option<Py<PyAny>>,
+        result_variable: Option<String>,
+    ) -> PyResult<Session> {
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    InitializationError::new_err(format!("failed to create runtime: {e}"))
+                })?,
+        );
+        // The artifact bytes are loaded directly because `PrecompiledArtifact`
+        // exposes no public executor-construction API, so the process-global
+        // `InstancePreCache` cannot be consulted here: a `cache=True` factory
+        // re-deserializes the component per session, unlike `create_sandbox()`,
+        // which routes it through `SandboxBuilder::with_precompiled_artifact`.
+        // Reusing the cached `InstancePre` is deliberately left to the follow-up
+        // session-performance work, which benchmarks creation before and after.
+        // SAFETY: the bytes were produced by `PythonExecutor::precompile` or
+        // loaded from a factory file created by this same API.
+        let mut executor =
+            unsafe { eryx::PythonExecutor::from_precompiled(self.precompiled.as_bytes()) }
+                .map_err(|e| {
+                    InitializationError::new_err(format!("failed to load factory runtime: {e}"))
+                })?;
+        executor = executor.with_python_stdlib(&self.stdlib_path);
+        if let Some(path) = &self.site_packages_path {
+            executor = executor.with_site_packages(path);
+        }
+        if let Some(name) = result_variable {
+            executor = executor.with_result_variable(name);
+        }
+        let limits = resource_limits.unwrap_or(ResourceLimits {
+            execution_timeout_ms: None,
+            callback_timeout_ms: Some(10_000),
+            max_memory_bytes: None,
+            max_callback_invocations: Some(1000),
+            max_fuel: None,
+            max_vfs_bytes: None,
+        });
+        let limits: eryx::ResourceLimits = (&limits).into();
+        Session::from_executor(
+            py,
+            Arc::new(executor),
+            runtime,
+            vfs,
+            vfs_mount_path,
+            limits,
+            network,
+            callbacks,
+            None,
+            volumes,
+            on_stdout,
+            on_stderr,
+            Some(Arc::clone(&self.extracted_packages)),
+        )
     }
 
     /// Create a new sandbox from this factory.

--- a/crates/eryx-python/src/preinit.rs
+++ b/crates/eryx-python/src/preinit.rs
@@ -267,20 +267,11 @@ impl SandboxFactory {
                     InitializationError::new_err(format!("failed to create runtime: {e}"))
                 })?,
         );
-        // The artifact bytes are loaded directly because `PrecompiledArtifact`
-        // exposes no public executor-construction API, so the process-global
-        // `InstancePreCache` cannot be consulted here: a `cache=True` factory
-        // re-deserializes the component per session, unlike `create_sandbox()`,
-        // which routes it through `SandboxBuilder::with_precompiled_artifact`.
-        // Reusing the cached `InstancePre` is deliberately left to the follow-up
-        // session-performance work, which benchmarks creation before and after.
         // SAFETY: the bytes were produced by `PythonExecutor::precompile` or
         // loaded from a factory file created by this same API.
-        let mut executor =
-            unsafe { eryx::PythonExecutor::from_precompiled(self.precompiled.as_bytes()) }
-                .map_err(|e| {
-                    InitializationError::new_err(format!("failed to load factory runtime: {e}"))
-                })?;
+        let mut executor = unsafe { self.precompiled.to_executor() }.map_err(|e| {
+            InitializationError::new_err(format!("failed to load factory runtime: {e}"))
+        })?;
         executor = executor.with_python_stdlib(&self.stdlib_path);
         if let Some(path) = &self.site_packages_path {
             executor = executor.with_site_packages(path);

--- a/crates/eryx-python/src/session.rs
+++ b/crates/eryx-python/src/session.rs
@@ -69,6 +69,127 @@ pub struct Session {
     net_config: Option<eryx::NetConfig>,
     /// Output handler for streaming stdout/stderr.
     output_handler: Option<Arc<dyn OutputHandler>>,
+    /// Keep extracted package directories alive for factory-created sessions.
+    #[allow(dead_code)]
+    package_storage_owner: Option<Arc<Vec<eryx::ExtractedPackage>>>,
+    /// Limits passed to callback handlers for this session.
+    callback_limits: eryx::ResourceLimits,
+}
+
+impl Session {
+    /// Build a session from a preconfigured executor. Factory sessions use this
+    /// path so ordinary `Session` construction remains unchanged.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_executor(
+        py: Python<'_>,
+        executor: Arc<eryx::PythonExecutor>,
+        runtime: Arc<tokio::runtime::Runtime>,
+        vfs: Option<VfsStorage>,
+        vfs_mount_path: Option<String>,
+        limits: eryx::ResourceLimits,
+        network: Option<NetConfig>,
+        callbacks: Option<Bound<'_, PyAny>>,
+        mcp: Option<PyRef<'_, crate::mcp::MCPManager>>,
+        volumes: Option<Vec<(String, String, bool)>>,
+        on_stdout: Option<Py<PyAny>>,
+        on_stderr: Option<Py<PyAny>>,
+        package_storage_owner: Option<Arc<Vec<eryx::ExtractedPackage>>>,
+    ) -> PyResult<Self> {
+        let callbacks_map: Arc<HashMap<String, Arc<dyn eryx::Callback>>> = {
+            let mut map = if let Some(ref cbs) = callbacks {
+                extract_callbacks(py, cbs)?
+                    .into_iter()
+                    .map(|c| (c.name().to_string(), Arc::new(c) as Arc<dyn eryx::Callback>))
+                    .collect()
+            } else {
+                HashMap::new()
+            };
+            if let Some(ref mcp_mgr) = mcp {
+                for c in mcp_mgr.as_callbacks() {
+                    let arc: Arc<dyn eryx::Callback> = Arc::new(c);
+                    map.insert(arc.name().to_string(), arc);
+                }
+            }
+            Arc::new(map)
+        };
+        let callbacks_vec: Vec<Arc<dyn eryx::Callback>> = callbacks_map.values().cloned().collect();
+        let volume_mounts = volumes
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(host, guest, ro)| {
+                if ro {
+                    eryx::VolumeMount::read_only(host, guest)
+                } else {
+                    eryx::VolumeMount::new(host, guest)
+                }
+            })
+            .collect::<Vec<_>>();
+        let vfs_storage = vfs.map(VfsStorage::into_arc_storage);
+        let mount_path = vfs_mount_path.clone();
+        let needs_vfs = vfs_storage.is_some() || !volume_mounts.is_empty();
+        let (inner, vfs_storage) = runtime
+            .block_on(async {
+                if needs_vfs {
+                    let storage = vfs_storage.unwrap_or_else(|| {
+                        let storage = match limits.max_vfs_bytes {
+                            Some(max_bytes) => {
+                                eryx::vfs::InMemoryStorage::with_max_bytes(max_bytes)
+                            }
+                            None => eryx::vfs::InMemoryStorage::new(),
+                        };
+                        eryx::vfs::ArcStorage::new(Arc::new(eryx::vfs::ScrubbingStorage::new(
+                            storage,
+                            HashMap::new(),
+                            eryx::vfs::VfsFileScrubPolicy::None,
+                        )))
+                    });
+                    let mut config = if let Some(path) = &mount_path {
+                        eryx::VfsConfig::new(path)
+                    } else {
+                        eryx::VfsConfig::default()
+                    };
+                    config.volumes = volume_mounts;
+                    let session = eryx::SessionExecutor::new_with_vfs_config_and_limits(
+                        Arc::clone(&executor),
+                        &callbacks_vec,
+                        storage.clone(),
+                        config,
+                        &limits,
+                    )
+                    .await?;
+                    Ok((session, Some(storage)))
+                } else {
+                    let session = eryx::SessionExecutor::new_with_limits(
+                        Arc::clone(&executor),
+                        &callbacks_vec,
+                        &limits,
+                    )
+                    .await?;
+                    Ok((session, None))
+                }
+            })
+            .map_err(eryx_error_to_py)?;
+        let output_handler = if on_stdout.is_some() || on_stderr.is_some() {
+            Some(Arc::new(PyOutputHandler {
+                on_stdout,
+                on_stderr,
+            }) as Arc<dyn OutputHandler>)
+        } else {
+            None
+        };
+        Ok(Self {
+            inner: Mutex::new(Some(inner)),
+            executor,
+            runtime,
+            vfs_storage,
+            vfs_mount_path: mount_path,
+            callbacks: callbacks_map,
+            net_config: network.map(Into::into),
+            output_handler,
+            package_storage_owner,
+            callback_limits: limits,
+        })
+    }
 }
 
 #[pymethods]
@@ -146,121 +267,26 @@ impl Session {
         }
         let executor = Arc::new(executor);
 
-        // Extract callbacks if provided
-        let callbacks_map: Arc<HashMap<String, Arc<dyn eryx::Callback>>> = {
-            let mut map: HashMap<String, Arc<dyn eryx::Callback>> = if let Some(ref cbs) = callbacks
-            {
-                let python_callbacks = extract_callbacks(py, cbs)?;
-                python_callbacks
-                    .into_iter()
-                    .map(|c| (c.name().to_string(), Arc::new(c) as Arc<dyn eryx::Callback>))
-                    .collect()
-            } else {
-                HashMap::new()
-            };
-
-            // Merge MCP callbacks if provided
-            if let Some(ref mcp_mgr) = mcp {
-                for c in mcp_mgr.as_callbacks() {
-                    let arc: Arc<dyn eryx::Callback> = Arc::new(c);
-                    map.insert(arc.name().to_string(), arc);
-                }
-            }
-
-            Arc::new(map)
-        };
-
-        // Convert to slice for SessionExecutor
-        let callbacks_vec: Vec<Arc<dyn eryx::Callback>> = callbacks_map.values().cloned().collect();
-
-        // Convert volume tuples to VolumeMount structs
-        let volume_mounts: Vec<eryx::VolumeMount> = volumes
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(host_path, guest_path, read_only)| {
-                if read_only {
-                    eryx::VolumeMount::read_only(host_path, guest_path)
-                } else {
-                    eryx::VolumeMount::new(host_path, guest_path)
-                }
-            })
-            .collect();
-
-        // Create the SessionExecutor
-        let vfs_storage = vfs.map(|v| v.into_arc_storage());
-        let mount_path = vfs_mount_path.clone();
-        let needs_vfs = vfs_storage.is_some() || !volume_mounts.is_empty();
-
-        let (inner, vfs_storage) = runtime
-            .block_on(async {
-                if needs_vfs {
-                    // Auto-create VFS storage if volumes are requested but no VFS provided
-                    let storage: eryx::vfs::ArcStorage = if let Some(s) = vfs_storage {
-                        s
-                    } else {
-                        eryx::vfs::ArcStorage::new(Arc::new(eryx::vfs::ScrubbingStorage::new(
-                            eryx::vfs::InMemoryStorage::new(),
-                            std::collections::HashMap::new(),
-                            eryx::vfs::VfsFileScrubPolicy::None,
-                        )))
-                    };
-                    let mut config = if let Some(path) = &mount_path {
-                        eryx::VfsConfig::new(path)
-                    } else {
-                        eryx::VfsConfig::default()
-                    };
-                    config.volumes = volume_mounts;
-                    let session = eryx::SessionExecutor::new_with_vfs_config(
-                        Arc::clone(&executor),
-                        &callbacks_vec,
-                        storage.clone(),
-                        config,
-                    )
-                    .await?;
-                    Ok((session, Some(storage)))
-                } else {
-                    let session =
-                        eryx::SessionExecutor::new(Arc::clone(&executor), &callbacks_vec).await?;
-                    Ok((session, None))
-                }
-            })
-            .map_err(eryx_error_to_py)?;
-
-        // Build output handler if streaming callbacks are provided
-        let output_handler: Option<Arc<dyn OutputHandler>> =
-            if on_stdout.is_some() || on_stderr.is_some() {
-                Some(Arc::new(PyOutputHandler {
-                    on_stdout,
-                    on_stderr,
-                }))
-            } else {
-                None
-            };
-
-        let net_config: Option<eryx::NetConfig> = network.map(Into::into);
-
-        let session = Self {
-            inner: Mutex::new(Some(inner)),
+        let limits = eryx::ResourceLimits::unlimited()
+            .with_execution_timeout(execution_timeout_ms.map(Duration::from_millis))
+            .with_max_fuel(max_fuel)
+            .with_callback_timeout(Some(Duration::from_secs(10)))
+            .with_max_callback_invocations(Some(1000));
+        Self::from_executor(
+            py,
             executor,
             runtime,
-            vfs_storage,
-            vfs_mount_path: mount_path,
-            callbacks: callbacks_map,
-            net_config,
-            output_handler,
-        };
-
-        // Set execution timeout if provided
-        if let Some(timeout_ms) = execution_timeout_ms {
-            session.set_execution_timeout_ms(Some(timeout_ms))?;
-        }
-
-        // Set fuel limit if provided
-        if max_fuel.is_some() {
-            session.set_fuel_limit(max_fuel)?;
-        }
-
-        Ok(session)
+            vfs,
+            vfs_mount_path,
+            limits,
+            network,
+            callbacks,
+            mcp,
+            volumes,
+            on_stdout,
+            on_stderr,
+            None,
+        )
     }
 
     /// Execute Python code in the session.
@@ -290,6 +316,7 @@ impl Session {
         let callbacks_map = self.callbacks.clone();
         let output_handler = self.output_handler.clone();
         let net_config = self.net_config.clone();
+        let callback_limits = self.callback_limits.clone();
 
         // Release the GIL while executing
         py.detach(|| {
@@ -316,7 +343,7 @@ impl Session {
                         eryx::callback_handler::run_callback_handler(
                             callback_rx,
                             handler_callbacks,
-                            eryx::ResourceLimits::default(),
+                            callback_limits,
                             std::sync::Arc::new(std::collections::HashMap::new()),
                         )
                         .await

--- a/crates/eryx-python/src/session.rs
+++ b/crates/eryx-python/src/session.rs
@@ -169,6 +169,9 @@ impl Session {
                 }
             })
             .map_err(eryx_error_to_py)?;
+        let callback_limits = eryx::ResourceLimits::unlimited()
+            .with_callback_timeout(limits.callback_timeout)
+            .with_max_callback_invocations(limits.max_callback_invocations);
         let output_handler = if on_stdout.is_some() || on_stderr.is_some() {
             Some(Arc::new(PyOutputHandler {
                 on_stdout,
@@ -187,7 +190,7 @@ impl Session {
             net_config: network.map(Into::into),
             output_handler,
             package_storage_owner,
-            callback_limits: limits,
+            callback_limits,
         })
     }
 }

--- a/crates/eryx-python/tests/test_factory_session.py
+++ b/crates/eryx-python/tests/test_factory_session.py
@@ -1,0 +1,205 @@
+"""Regression tests for factory-backed persistent sessions."""
+
+import gc
+import threading
+import time
+import zipfile
+
+import eryx
+import pytest
+
+
+def test_factory_session_persistent_state_and_full_reset(sandbox_factory):
+    session = sandbox_factory.create_session()
+    assert session.execution_timeout_ms is None
+    assert session.fuel_limit is None
+    session.execute("value = 41")
+    assert session.execute("print(value + 1)").stdout == "42"
+    session.reset()
+    with pytest.raises(eryx.ExecutionError):
+        session.execute("print(value)")
+
+
+def test_factory_session_result_and_reset(sandbox_factory):
+    session = sandbox_factory.create_session(result_variable="answer")
+    assert session.execute("answer = {'ok': True}").result == {"ok": True}
+    session.reset()
+    assert session.execute("answer = 7").result == 7
+
+
+def test_factory_session_memory_growth_rejected(sandbox_factory):
+    with pytest.raises(eryx.InitializationError):
+        sandbox_factory.create_session(
+            resource_limits=eryx.ResourceLimits(max_memory_bytes=1)
+        )
+    session = sandbox_factory.create_session(
+        resource_limits=eryx.ResourceLimits(max_memory_bytes=128 * 1024 * 1024)
+    )
+    session.execute("x = bytearray(1024)")
+    with pytest.raises((eryx.ExecutionError, eryx.ResourceLimitError)):
+        session.execute("x = bytearray(512 * 1024 * 1024)")
+    session.reset()
+    with pytest.raises((eryx.ExecutionError, eryx.ResourceLimitError)):
+        session.execute("x = bytearray(512 * 1024 * 1024)")
+
+
+def test_factory_session_timeout_and_fuel_limits(sandbox_factory):
+    timeout = sandbox_factory.create_session(
+        resource_limits=eryx.ResourceLimits(execution_timeout_ms=100)
+    )
+    with pytest.raises(eryx.TimeoutError):
+        timeout.execute("while True: pass")
+
+    fuel = sandbox_factory.create_session(
+        resource_limits=eryx.ResourceLimits(max_fuel=100)
+    )
+    with pytest.raises(eryx.ResourceLimitError):
+        fuel.execute("while True: pass")
+    fuel.reset()
+    with pytest.raises(eryx.ResourceLimitError):
+        fuel.execute("while True: pass")
+
+
+def test_ordinary_session_defaults_remain_unchanged():
+    session = eryx.Session()
+    assert session.execution_timeout_ms is None
+    assert session.vfs is None
+
+    # vfs_mount_path relocates caller-supplied storage; alone it must not
+    # materialise a VFS, so a storage-less session still reports none.
+    bare = eryx.Session(vfs_mount_path="/custom")
+    assert bare.vfs is None
+    assert bare.vfs_mount_path is None
+
+
+def test_factory_session_callback_count_applies_after_reset(sandbox_factory):
+    calls = []
+
+    def callback():
+        calls.append(1)
+        return len(calls)
+
+    session = sandbox_factory.create_session(
+        callbacks=[{"name": "count", "fn": callback}],
+        resource_limits=eryx.ResourceLimits(max_callback_invocations=1),
+    )
+    assert session.execute("print(await count())").stdout == "1"
+    assert session.execute("print(await count())").stdout == "2"
+    session.reset()
+    with pytest.raises(eryx.ExecutionError):
+        session.execute("await count(); await count()")
+    assert len(calls) == 3
+
+
+def test_factory_session_callback_timeout(sandbox_factory):
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def slow_callback():
+        started.set()
+        try:
+            release.wait(timeout=5)
+            return 1
+        finally:
+            finished.set()
+
+    session = sandbox_factory.create_session(
+        callbacks=[{"name": "slow", "fn": slow_callback}],
+        resource_limits=eryx.ResourceLimits(callback_timeout_ms=50),
+    )
+    started_at = time.monotonic()
+    try:
+        with pytest.raises(eryx.ExecutionError, match="timeout"):
+            session.execute("await slow()")
+        assert started.is_set()
+        assert time.monotonic() - started_at < 1.0
+    finally:
+        # spawn_blocking work continues after the host timeout.
+        release.set()
+        assert finished.wait(timeout=5)
+
+
+def test_factory_session_caller_vfs_keeps_own_policy_and_mount_path(sandbox_factory):
+    storage = eryx.VfsStorage()
+    session = sandbox_factory.create_session(
+        vfs=storage,
+        vfs_mount_path="/custom",
+        resource_limits=eryx.ResourceLimits(max_vfs_bytes=1),
+    )
+    session.execute("with open('/custom/a', 'w') as f: f.write('caller-owned')")
+    session.reset()
+    assert session.execute("print(open('/custom/a').read())").stdout == "caller-owned"
+    assert session.vfs_mount_path == "/custom"
+
+
+def test_factory_session_volumes_output_and_native_import(
+    sandbox_factory, markupsafe_wheel, tmp_path
+):
+    volume = tmp_path / "volume"
+    volume.mkdir()
+    output = []
+    errors = []
+    session = sandbox_factory.create_session(
+        volumes=[(str(volume), "/mnt", True)],
+        on_stdout=output.append,
+        on_stderr=errors.append,
+    )
+    assert session.execute("import os; print(os.path.isdir('/mnt'))").stdout == "True"
+    assert output
+    with pytest.raises(eryx.ExecutionError):
+        session.execute("with open('/mnt/nope', 'w') as f: f.write('x')")
+    session.execute("import sys; print('diagnostic', file=sys.stderr)")
+    assert errors
+
+    factory = eryx.SandboxFactory(packages=[str(markupsafe_wheel)], imports=[])
+    imported = factory.create_session(on_stdout=output.append)
+    del factory
+    gc.collect()
+    assert (
+        imported.execute(
+            "import markupsafe; import markupsafe._speedups; "
+            "print(markupsafe._speedups.__name__)"
+        ).stdout
+        == "markupsafe._speedups"
+    )
+
+
+def test_factory_session_network(http_server, sandbox_factory):
+    host, port = http_server
+    net = eryx.NetConfig.permissive().allow_localhost()
+    session = sandbox_factory.create_session(network=net)
+    result = session.execute(f"""
+import socket
+
+sock = socket.create_connection(("{host}", {port}), timeout=5)
+sock.sendall(b"GET / HTTP/1.1\\r\\nHost: {host}:{port}\\r\\nConnection: close\\r\\n\\r\\n")
+chunks = []
+while True:
+    chunk = sock.recv(4096)
+    if not chunk:
+        break
+    chunks.append(chunk)
+sock.close()
+print(b"".join(chunks).decode(errors="replace"))
+""")
+    assert "Hello from test server" in result.stdout
+
+
+def test_factory_session_preimport_and_local_wheel_lifetime(sandbox_factory, tmp_path):
+    wheel = tmp_path / "tiny-1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tiny_late.py", "VALUE = 42\n")
+        archive.writestr(
+            "tiny-1.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: tiny\nVersion: 1.0\n",
+        )
+        archive.writestr("tiny-1.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+    factory = eryx.SandboxFactory(packages=[str(wheel)], imports=["json"])
+    session = factory.create_session()
+    assert session.execute("import sys; print('json' in sys.modules)").stdout == "True"
+    del factory
+    gc.collect()
+    assert session.execute("import tiny_late; print(tiny_late.VALUE)").stdout == "42"
+    session.reset()
+    assert session.execute("import tiny_late; print(tiny_late.VALUE)").stdout == "42"

--- a/crates/eryx-python/tests/test_factory_session.py
+++ b/crates/eryx-python/tests/test_factory_session.py
@@ -83,6 +83,7 @@ def test_factory_session_callback_count_applies_after_reset(sandbox_factory):
         callbacks=[{"name": "count", "fn": callback}],
         resource_limits=eryx.ResourceLimits(max_callback_invocations=1),
     )
+    # max_callback_invocations is per execution, so both single-callback calls succeed.
     assert session.execute("print(await count())").stdout == "1"
     assert session.execute("print(await count())").stdout == "2"
     session.reset()
@@ -203,3 +204,51 @@ def test_factory_session_preimport_and_local_wheel_lifetime(sandbox_factory, tmp
     assert session.execute("import tiny_late; print(tiny_late.VALUE)").stdout == "42"
     session.reset()
     assert session.execute("import tiny_late; print(tiny_late.VALUE)").stdout == "42"
+
+
+def test_saved_factory_session_lazily_imports_from_supplied_site_packages(tmp_path):
+    site_packages = tmp_path / "site-packages"
+    package = site_packages / "saved_factory_package"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("VALUE = 42\n")
+
+    save_path = tmp_path / "factory.bin"
+    factory = eryx.SandboxFactory(site_packages=site_packages, imports=[])
+    factory.save(save_path)
+
+    loaded = eryx.SandboxFactory.load(save_path, site_packages=site_packages)
+    session = loaded.create_session()
+    assert (
+        session.execute(
+            "import sys; print('saved_factory_package' not in sys.modules)"
+        ).stdout
+        == "True"
+    )
+    assert (
+        session.execute(
+            "import saved_factory_package; print(saved_factory_package.VALUE)"
+        ).stdout
+        == "42"
+    )
+
+
+def test_cached_loaded_factory_sessions_are_isolated_and_equivalent(
+    sandbox_factory, tmp_path
+):
+    save_path = tmp_path / "cached-factory.bin"
+    sandbox_factory.save(save_path)
+    loaded = eryx.SandboxFactory.load(save_path, cache=True)
+
+    first = loaded.create_session()
+    second = loaded.create_session()
+    assert first.execute("print('clean' if 'state' not in globals() else 'dirty')").stdout == (
+        "clean"
+    )
+    assert second.execute("print('clean' if 'state' not in globals() else 'dirty')").stdout == (
+        "clean"
+    )
+
+    first.execute("state = 'first'")
+    second.execute("state = 'second'")
+    assert first.execute("print(state)").stdout == "first"
+    assert second.execute("print(state)").stdout == "second"

--- a/crates/eryx/src/sandbox.rs
+++ b/crates/eryx/src/sandbox.rs
@@ -1150,8 +1150,34 @@ impl PrecompiledArtifact {
         self.bytes.is_empty()
     }
 
-    fn cache_key(&self) -> Option<&crate::cache::CacheKey> {
-        self.cache_key.as_ref()
+    /// Build a [`PythonExecutor`] from this artifact, consulting the
+    /// process-global [`crate::cache::InstancePreCache`] when it carries a
+    /// cache key.
+    ///
+    /// On a cache hit this skips deserializing the component bytes. Artifacts
+    /// without a cache key use the uncached loading path.
+    ///
+    /// # Safety
+    ///
+    /// Pre-compiled bytes cannot be fully validated by Wasmtime. Only construct
+    /// executors from artifacts created by [`PythonExecutor::precompile`] from
+    /// trusted components.
+    #[allow(unsafe_code)]
+    pub unsafe fn to_executor(&self) -> std::result::Result<PythonExecutor, Error> {
+        #[cfg(feature = "embedded")]
+        if let Some(key) = &self.cache_key {
+            // SAFETY: The caller guarantees that the artifact bytes are trusted.
+            #[allow(unsafe_code)]
+            return unsafe {
+                PythonExecutor::from_precompiled_with_key(self.as_bytes(), key.clone())
+            };
+        }
+
+        // SAFETY: The caller guarantees that the artifact bytes are trusted.
+        #[allow(unsafe_code)]
+        unsafe {
+            PythonExecutor::from_precompiled(self.as_bytes())
+        }
     }
 }
 
@@ -2437,7 +2463,7 @@ impl SandboxBuilder<state::Has, state::Has> {
                 // caller has acknowledged this responsibility.
                 #[allow(unsafe_code)]
                 unsafe {
-                    Self::load_precompiled(bytes, None)?
+                    PythonExecutor::from_precompiled(bytes)?
                 }
             }
 
@@ -2448,7 +2474,7 @@ impl SandboxBuilder<state::Has, state::Has> {
                 // the caller has acknowledged this responsibility.
                 #[allow(unsafe_code)]
                 unsafe {
-                    Self::load_precompiled(artifact.as_bytes(), artifact.cache_key())?
+                    artifact.to_executor()?
                 }
             }
 
@@ -2489,36 +2515,6 @@ impl SandboxBuilder<state::Has, state::Has> {
         };
 
         Ok(executor)
-    }
-
-    /// Load a pre-compiled component, using the global [`InstancePreCache`]
-    /// when a cache key is configured.
-    ///
-    /// # Safety
-    ///
-    /// Caller guarantees the pre-compiled bytes are trusted and were created
-    /// by `PythonExecutor::precompile()` with a compatible engine configuration.
-    #[cfg(any(feature = "embedded", feature = "preinit"))]
-    #[allow(unsafe_code)]
-    unsafe fn load_precompiled(
-        bytes: &[u8],
-        cache_key: Option<&crate::cache::CacheKey>,
-    ) -> Result<PythonExecutor, Error> {
-        #[cfg(feature = "embedded")]
-        if let Some(key) = cache_key {
-            // SAFETY: Caller guarantees the pre-compiled bytes are trusted.
-            #[allow(unsafe_code)]
-            return unsafe { PythonExecutor::from_precompiled_with_key(bytes, key.clone()) };
-        }
-        // Without `embedded` there is no cache to consult; the key is unused.
-        #[cfg(not(feature = "embedded"))]
-        let _ = cache_key;
-
-        // SAFETY: Caller guarantees the pre-compiled bytes are trusted.
-        #[allow(unsafe_code)]
-        unsafe {
-            PythonExecutor::from_precompiled(bytes)
-        }
     }
 
     /// Build executor with native extensions, using cache if available.

--- a/crates/eryx/src/session/executor.rs
+++ b/crates/eryx/src/session/executor.rs
@@ -49,6 +49,7 @@ use wasmtime_wasi::{FsPerms, WasiCtx, WasiCtxBuilder};
 
 use crate::callback::Callback;
 use crate::error::Error;
+use crate::sandbox::ResourceLimits;
 use crate::wasm::{
     CallbackRequest, ExecutionOutput, ExecutorState, HostCallbackInfo, MemoryTracker, NetRequest,
     PythonExecutor, Sandbox as SandboxBindings, TraceRequest,
@@ -463,6 +464,9 @@ pub struct SessionExecutor {
     /// Optional fuel limit for instruction tracking/limiting.
     fuel_limit: Option<u64>,
 
+    /// Maximum guest memory, preserved when the store is recreated.
+    memory_limit: Option<u64>,
+
     /// VFS storage that persists across resets.
     #[cfg(feature = "vfs")]
     vfs_storage: Option<eryx_vfs::ArcStorage>,
@@ -470,6 +474,10 @@ pub struct SessionExecutor {
     /// VFS configuration that persists across resets.
     #[cfg(feature = "vfs")]
     vfs_config: Option<VfsConfig>,
+
+    /// Quota used when creating the session's own VFS storage.
+    #[cfg(feature = "vfs")]
+    vfs_max_bytes: Option<u64>,
 }
 
 impl std::fmt::Debug for SessionExecutor {
@@ -480,6 +488,7 @@ impl std::fmt::Debug for SessionExecutor {
             .field("has_bindings", &self.bindings.is_some())
             .field("execution_timeout", &self.execution_timeout)
             .field("fuel_limit", &self.fuel_limit)
+            .field("memory_limit", &self.memory_limit)
             .finish_non_exhaustive()
     }
 }
@@ -497,6 +506,19 @@ fn build_callback_infos(callbacks: &[Arc<dyn Callback>]) -> Vec<HostCallbackInfo
         .collect()
 }
 
+/// Guest mount path for the `index`-th site-packages directory.
+///
+/// Index 0 is mounted at `/site-packages` because the preinitialized snapshot
+/// bakes that path into `sys.path`; later directories get an index suffix.
+/// This matches the sandbox mount scheme in [`crate::wasm`].
+fn site_packages_mount_path(index: usize) -> String {
+    if index == 0 {
+        "/site-packages".to_string()
+    } else {
+        format!("/site-packages-{index}")
+    }
+}
+
 /// Build WASI context with Python stdlib and site-packages mounts.
 fn build_wasi_context(executor: &PythonExecutor) -> Result<WasiCtx, Error> {
     let mut wasi_builder = WasiCtxBuilder::new();
@@ -509,7 +531,7 @@ fn build_wasi_context(executor: &PythonExecutor) -> Result<WasiCtx, Error> {
         pythonpath_parts.push("/python-stdlib".to_string());
     }
     for i in 0..site_packages_paths.len() {
-        pythonpath_parts.push(format!("/site-packages-{i}"));
+        pythonpath_parts.push(site_packages_mount_path(i));
     }
 
     // Mount Python stdlib if configured (required for eryx-wasm-runtime)
@@ -523,9 +545,9 @@ fn build_wasi_context(executor: &PythonExecutor) -> Result<WasiCtx, Error> {
             .map_err(|e| Error::WasmEngine(format!("Failed to mount Python stdlib: {e}")))?;
     }
 
-    // Mount each site-packages directory at a unique path
+    // Mount each site-packages directory (index 0 keeps the baked sys.path)
     for (i, site_packages_path) in site_packages_paths.iter().enumerate() {
-        let mount_path = format!("/site-packages-{i}");
+        let mount_path = site_packages_mount_path(i);
         wasi_builder
             .preopened_dir(site_packages_path, &mount_path, FsPerms::ReadOnly)
             .map_err(|e| Error::WasmEngine(format!("Failed to mount {mount_path}: {e}")))?;
@@ -558,7 +580,7 @@ fn build_hybrid_vfs_context(
         ctx.add_real_preopen("/python-stdlib", real_dir);
     }
     for (i, site_packages_path) in executor.python_site_packages_paths().iter().enumerate() {
-        let mount_path = format!("/site-packages-{i}");
+        let mount_path = site_packages_mount_path(i);
         if let Ok(real_dir) =
             eryx_vfs::RealDir::open_ambient(site_packages_path, DirPerms::READ, FilePerms::READ)
         {
@@ -617,13 +639,33 @@ impl SessionExecutor {
         executor: Arc<PythonExecutor>,
         callbacks: &[Arc<dyn Callback>],
     ) -> Result<Self, Error> {
+        Self::new_with_limits(executor, callbacks, &ResourceLimits::unlimited()).await
+    }
+
+    /// Create a session with the supplied execution and resource limits.
+    ///
+    /// The limits are applied before component instantiation, so the memory
+    /// cap also bounds initial memory growth. The execution timeout and fuel
+    /// limit apply to every execution and are retained when the session is
+    /// reset. Callback timeout and invocation-count limits remain the
+    /// responsibility of the callback handler; this low-level executor only
+    /// forwards callback requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the component cannot be instantiated.
+    pub async fn new_with_limits(
+        executor: Arc<PythonExecutor>,
+        callbacks: &[Arc<dyn Callback>],
+        limits: &ResourceLimits,
+    ) -> Result<Self, Error> {
         #[cfg(feature = "vfs")]
         {
-            Self::new_internal(executor, callbacks, None, None).await
+            Self::new_internal(executor, callbacks, None, None, limits).await
         }
         #[cfg(not(feature = "vfs"))]
         {
-            Self::new_internal(executor, callbacks).await
+            Self::new_internal(executor, callbacks, limits).await
         }
     }
 
@@ -648,7 +690,14 @@ impl SessionExecutor {
         callbacks: &[Arc<dyn Callback>],
         vfs_storage: eryx_vfs::ArcStorage,
     ) -> Result<Self, Error> {
-        Self::new_internal(executor, callbacks, Some(vfs_storage), None).await
+        Self::new_internal(
+            executor,
+            callbacks,
+            Some(vfs_storage),
+            None,
+            &ResourceLimits::unlimited(),
+        )
+        .await
     }
 
     /// Create a new session executor with custom VFS storage and configuration.
@@ -689,7 +738,41 @@ impl SessionExecutor {
         vfs_storage: eryx_vfs::ArcStorage,
         vfs_config: VfsConfig,
     ) -> Result<Self, Error> {
-        Self::new_internal(executor, callbacks, Some(vfs_storage), Some(vfs_config)).await
+        Self::new_internal(
+            executor,
+            callbacks,
+            Some(vfs_storage),
+            Some(vfs_config),
+            &ResourceLimits::unlimited(),
+        )
+        .await
+    }
+
+    /// Create a session with caller-owned VFS storage and resource limits.
+    ///
+    /// The supplied storage retains ownership of its own quota and policy;
+    /// `limits.max_vfs_bytes` is only used for storage created by Eryx.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the WASM component cannot be instantiated or a VFS
+    /// mount cannot be created.
+    #[cfg(feature = "vfs")]
+    pub async fn new_with_vfs_config_and_limits(
+        executor: Arc<PythonExecutor>,
+        callbacks: &[Arc<dyn Callback>],
+        vfs_storage: eryx_vfs::ArcStorage,
+        vfs_config: VfsConfig,
+        limits: &ResourceLimits,
+    ) -> Result<Self, Error> {
+        Self::new_internal(
+            executor,
+            callbacks,
+            Some(vfs_storage),
+            Some(vfs_config),
+            limits,
+        )
+        .await
     }
 
     /// Internal constructor with optional VFS storage and config.
@@ -699,13 +782,19 @@ impl SessionExecutor {
         callbacks: &[Arc<dyn Callback>],
         vfs_storage: Option<eryx_vfs::ArcStorage>,
         vfs_config: Option<VfsConfig>,
+        limits: &ResourceLimits,
     ) -> Result<Self, Error> {
         let callback_infos = build_callback_infos(callbacks);
         let wasi = build_wasi_context(&executor)?;
 
-        // Use provided storage/config or create defaults (plain in-memory, no scrubbing)
+        // Use provided storage/config or create defaults. A storage supplied by
+        // the caller owns its own quota; max_vfs_bytes applies only here.
         let vfs_storage = vfs_storage.unwrap_or_else(|| {
-            eryx_vfs::ArcStorage::new(std::sync::Arc::new(eryx_vfs::InMemoryStorage::new()))
+            eryx_vfs::ArcStorage::new(std::sync::Arc::new(
+                eryx_vfs::InMemoryStorage::with_max_bytes(
+                    limits.max_vfs_bytes.unwrap_or(eryx_vfs::DEFAULT_MAX_BYTES),
+                ),
+            ))
         });
         let vfs_config = vfs_config.unwrap_or_default();
 
@@ -721,7 +810,7 @@ impl SessionExecutor {
             None,
             None,
             callback_infos,
-            MemoryTracker::new(None),
+            MemoryTracker::new(limits.max_memory_bytes),
             hybrid_vfs_ctx,
         );
 
@@ -767,10 +856,12 @@ impl SessionExecutor {
             store: Some(store),
             bindings: Some(bindings),
             execution_count: 0,
-            execution_timeout: None,
-            fuel_limit: None,
+            execution_timeout: limits.execution_timeout,
+            fuel_limit: limits.max_fuel,
+            memory_limit: limits.max_memory_bytes,
             vfs_storage: Some(vfs_storage),
             vfs_config: Some(vfs_config),
+            vfs_max_bytes: limits.max_vfs_bytes,
         })
     }
 
@@ -779,6 +870,7 @@ impl SessionExecutor {
     async fn new_internal(
         executor: Arc<PythonExecutor>,
         callbacks: &[Arc<dyn Callback>],
+        limits: &ResourceLimits,
     ) -> Result<Self, Error> {
         let callback_infos = build_callback_infos(callbacks);
         let wasi = build_wasi_context(&executor)?;
@@ -789,7 +881,7 @@ impl SessionExecutor {
             None,
             None,
             callback_infos,
-            MemoryTracker::new(None),
+            MemoryTracker::new(limits.max_memory_bytes),
         );
 
         // Create store
@@ -832,8 +924,9 @@ impl SessionExecutor {
             store: Some(store),
             bindings: Some(bindings),
             execution_count: 0,
-            execution_timeout: None,
-            fuel_limit: None,
+            execution_timeout: limits.execution_timeout,
+            fuel_limit: limits.max_fuel,
+            memory_limit: limits.max_memory_bytes,
         })
     }
 
@@ -1152,14 +1245,20 @@ impl SessionExecutor {
             None,
             None,
             callback_infos,
-            MemoryTracker::new(None),
+            MemoryTracker::new(self.memory_limit),
         );
 
         #[cfg(feature = "vfs")]
         let state = {
             // Reuse existing VFS storage and config so files persist across resets
             let vfs_storage = self.vfs_storage.clone().unwrap_or_else(|| {
-                eryx_vfs::ArcStorage::new(std::sync::Arc::new(eryx_vfs::InMemoryStorage::new()))
+                // This is only a defensive fallback (constructors always keep
+                // the storage), but retain the configured quota if it is used.
+                eryx_vfs::ArcStorage::new(std::sync::Arc::new(
+                    eryx_vfs::InMemoryStorage::with_max_bytes(
+                        self.vfs_max_bytes.unwrap_or(eryx_vfs::DEFAULT_MAX_BYTES),
+                    ),
+                ))
             });
             let vfs_config = self.vfs_config.clone().unwrap_or_default();
 
@@ -1169,7 +1268,7 @@ impl SessionExecutor {
                 None,
                 None,
                 callback_infos,
-                MemoryTracker::new(None),
+                MemoryTracker::new(self.memory_limit),
                 Some(build_hybrid_vfs_context(
                     &self.executor,
                     vfs_storage,

--- a/crates/eryx/src/session/in_process.rs
+++ b/crates/eryx/src/session/in_process.rs
@@ -86,8 +86,12 @@ impl std::fmt::Debug for InProcessSession<'_> {
 impl<'a> InProcessSession<'a> {
     /// Create a new in-process session from a sandbox.
     ///
-    /// The session will share the sandbox's configuration (callbacks, preamble, etc.)
-    /// but maintain its own persistent state.
+    /// The session will share the sandbox's configuration (callbacks, preamble,
+    /// and resource limits) but maintain its own persistent state. Its memory
+    /// limit is applied while the WASM instance is created, while timeout and
+    /// fuel limits apply to each execution and remain in force after [`Self::reset`]. Callback
+    /// timeout and invocation-count limits continue to be enforced by the
+    /// callback handler.
     ///
     /// # Errors
     ///
@@ -103,10 +107,15 @@ impl<'a> InProcessSession<'a> {
     pub async fn new(sandbox: &'a Sandbox) -> Result<Self, Error> {
         let callbacks: Vec<Arc<dyn Callback>> = sandbox.callbacks().values().cloned().collect();
 
-        let mut executor = SessionExecutor::new(sandbox.executor().clone(), &callbacks).await?;
-
-        // Set execution timeout from sandbox resource limits
-        executor.set_execution_timeout(sandbox.resource_limits().execution_timeout);
+        // Construct the store with the sandbox's execution, memory, and VFS
+        // limits so memory growth is constrained during instantiation, not
+        // only execution. Callback limits remain handler-owned below.
+        let executor = SessionExecutor::new_with_limits(
+            sandbox.executor().clone(),
+            &callbacks,
+            sandbox.resource_limits(),
+        )
+        .await?;
 
         Ok(Self {
             sandbox,

--- a/crates/eryx/tests/session_limits.rs
+++ b/crates/eryx/tests/session_limits.rs
@@ -1,0 +1,292 @@
+//! Regression coverage for limits on persistent sessions.
+#![cfg(feature = "embedded")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::{Arc, OnceLock};
+
+use eryx::{
+    Error, InProcessSession, PythonExecutor, ResourceLimits, Sandbox, Session, SessionExecutor,
+};
+
+static EXECUTOR: OnceLock<Arc<PythonExecutor>> = OnceLock::new();
+
+fn executor() -> Arc<PythonExecutor> {
+    EXECUTOR
+        .get_or_init(|| {
+            let resources = eryx::embedded::EmbeddedResources::get().unwrap();
+            #[allow(unsafe_code)]
+            Arc::new(
+                unsafe { PythonExecutor::from_precompiled_file(resources.runtime()) }
+                    .unwrap()
+                    .with_python_stdlib(resources.stdlib()),
+            )
+        })
+        .clone()
+}
+
+async fn limited_session(limits: ResourceLimits) -> SessionExecutor {
+    SessionExecutor::new_with_limits(executor(), &[], &limits)
+        .await
+        .expect("session construction")
+}
+
+async fn ordinary_session() -> SessionExecutor {
+    SessionExecutor::new(executor(), &[])
+        .await
+        .expect("session construction")
+}
+
+fn assert_memory_limit_error(error: Error) {
+    let message = error.to_string().to_lowercase();
+    assert!(
+        message.contains("memory"),
+        "unexpected memory-limit error: {error:?}"
+    );
+}
+
+/// Assert that a guest write was rejected by a VFS quota.
+///
+/// [`eryx::vfs`] documents `QuotaExceeded` as guest-visible `ENOSPC`, but the
+/// rejection currently reaches CPython's close path as a generic `OSError`.
+/// This asserts only that the write failed, because the errno classification is
+/// pre-existing behavior unrelated to limit propagation.
+fn assert_vfs_quota_rejected(error: &Error) {
+    assert!(
+        matches!(error, Error::PythonException(_)) && error.to_string().contains("OSError"),
+        "expected a guest-visible VFS quota rejection, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn ordinary_session_still_executes_and_preserves_state() {
+    let mut session = ordinary_session().await;
+    // The limit-free constructor must stay limit-free: inheriting
+    // `ResourceLimits::default()` here would silently add a 30 s timeout and a
+    // 128 MB cap to every existing caller of `SessionExecutor::new`.
+    assert_eq!(session.execution_timeout(), None);
+    assert_eq!(session.fuel_limit(), None);
+    session.execute("x = 41").run().await.expect("assignment");
+    let output = session
+        .execute("print(x + 1)")
+        .run()
+        .await
+        .expect("stateful execution");
+    assert_eq!(output.stdout.trim(), "42");
+}
+
+#[tokio::test]
+async fn memory_limit_is_enforced_and_survives_reset() {
+    let mut unlimited = limited_session(ResourceLimits::unlimited()).await;
+    let peak = unlimited
+        .execute("x = bytearray(64 * 1024 * 1024)")
+        .run()
+        .await
+        .expect("allocation")
+        .peak_memory_bytes;
+
+    let limits = ResourceLimits::unlimited().with_max_memory_bytes(peak - 1);
+    let mut session = limited_session(limits).await;
+    session
+        .execute("x = 1")
+        .run()
+        .await
+        .expect("small allocation");
+    assert_memory_limit_error(
+        session
+            .execute("x = bytearray(64 * 1024 * 1024)")
+            .run()
+            .await
+            .expect_err("allocation should exceed the memory limit"),
+    );
+    session.reset(&[]).await.expect("reset");
+    assert_memory_limit_error(
+        session
+            .execute("x = bytearray(64 * 1024 * 1024)")
+            .run()
+            .await
+            .expect_err("memory limit must survive reset"),
+    );
+}
+
+#[tokio::test]
+async fn fuel_limit_is_applied_at_construction_and_reset() {
+    let mut session = limited_session(ResourceLimits::unlimited().with_max_fuel(1)).await;
+    assert!(
+        matches!(
+            session.execute("x = 1").run().await,
+            Err(Error::FuelExhausted { limit: 1, .. })
+        ),
+        "fuel limit should be applied at construction"
+    );
+    session.reset(&[]).await.expect("reset");
+    assert!(
+        matches!(
+            session.execute("x = 1").run().await,
+            Err(Error::FuelExhausted { limit: 1, .. })
+        ),
+        "fuel limit should survive reset"
+    );
+}
+
+#[tokio::test]
+async fn timeout_limit_is_applied_at_construction_and_reset() {
+    let limits =
+        ResourceLimits::unlimited().with_execution_timeout(std::time::Duration::from_millis(100));
+    let mut session = limited_session(limits).await;
+    assert!(
+        matches!(
+            session.execute("while True: pass").run().await,
+            Err(Error::Timeout(duration)) if duration == std::time::Duration::from_millis(100)
+        ),
+        "timeout should be applied at construction"
+    );
+    session.reset(&[]).await.expect("reset");
+    assert!(
+        matches!(
+            session.execute("while True: pass").run().await,
+            Err(Error::Timeout(duration)) if duration == std::time::Duration::from_millis(100)
+        ),
+        "timeout should survive reset"
+    );
+}
+
+#[tokio::test]
+async fn memory_limit_can_reject_initial_store_growth() {
+    let limits = ResourceLimits::unlimited().with_max_memory_bytes(1);
+    assert_memory_limit_error(
+        SessionExecutor::new_with_limits(executor(), &[], &limits)
+            .await
+            .expect_err("an impossibly small memory limit must reject instantiation"),
+    );
+}
+
+#[tokio::test]
+async fn in_process_session_receives_sandbox_limits() {
+    let limits = ResourceLimits::unlimited().with_max_fuel(1);
+    let sandbox = Sandbox::builder()
+        .with_embedded_runtime()
+        .with_resource_limits(limits)
+        .build()
+        .expect("sandbox construction");
+    let mut session = InProcessSession::new(&sandbox)
+        .await
+        .expect("session construction");
+
+    assert!(
+        matches!(
+            session.execute("x = 1").await,
+            Err(Error::FuelExhausted { limit: 1, .. })
+        ),
+        "InProcessSession must apply the sandbox fuel limit"
+    );
+    session.reset().await.expect("reset");
+    assert!(
+        matches!(
+            session.execute("x = 1").await,
+            Err(Error::FuelExhausted { limit: 1, .. })
+        ),
+        "InProcessSession must preserve the fuel limit after reset"
+    );
+}
+
+#[tokio::test]
+async fn in_process_session_applies_memory_limit_at_instantiation() {
+    let sandbox = Sandbox::builder()
+        .with_embedded_runtime()
+        .with_resource_limits(ResourceLimits::unlimited().with_max_memory_bytes(1))
+        .build()
+        .expect("sandbox construction");
+    let error = InProcessSession::new(&sandbox)
+        .await
+        .expect_err("an impossibly small memory limit must reject the session");
+    assert_memory_limit_error(error);
+}
+
+#[cfg(feature = "vfs")]
+#[tokio::test]
+async fn caller_owned_vfs_quota_is_not_replaced_by_resource_limits() {
+    use eryx::vfs::{ArcStorage, InMemoryStorage, VfsStorage};
+
+    let storage = ArcStorage::new(Arc::new(InMemoryStorage::with_max_bytes(4)));
+    let mut session = SessionExecutor::new_with_vfs_config_and_limits(
+        executor(),
+        &[],
+        storage.clone(),
+        eryx::VfsConfig::default(),
+        &ResourceLimits::unlimited().with_max_vfs_bytes(1024),
+    )
+    .await
+    .expect("session construction");
+
+    session
+        .execute("with open('/data/file', 'wb') as f:\n    f.write(b'1234')")
+        .run()
+        .await
+        .expect("write within caller quota");
+    assert_eq!(
+        storage.read("/data/file").await.expect("read baseline"),
+        b"1234"
+    );
+
+    let result = session
+        .execute("with open('/data/file', 'ab') as f:\n    f.write(b'5')")
+        .run()
+        .await;
+    let error = result.expect_err("caller storage quota must reject the write");
+    assert_vfs_quota_rejected(&error);
+    assert_eq!(
+        storage
+            .read("/data/file")
+            .await
+            .expect("read after failed write"),
+        b"1234"
+    );
+    session.reset(&[]).await.expect("reset");
+    assert_eq!(
+        storage.read("/data/file").await.expect("read after reset"),
+        b"1234"
+    );
+    let error = session
+        .execute("with open('/data/file', 'ab') as f:\n    f.write(b'5')")
+        .run()
+        .await
+        .expect_err("caller quota must survive reset");
+    assert_vfs_quota_rejected(&error);
+}
+
+#[cfg(feature = "vfs")]
+#[tokio::test]
+async fn owned_vfs_quota_survives_reset() {
+    let limits = ResourceLimits::unlimited().with_max_vfs_bytes(4);
+    let mut session = SessionExecutor::new_with_limits(executor(), &[], &limits)
+        .await
+        .expect("session construction");
+    session
+        .execute("with open('/data/file', 'wb') as f:\n    f.write(b'1234')")
+        .run()
+        .await
+        .expect("write within owned quota");
+    let error = session
+        .execute("with open('/data/file', 'ab') as f:\n    f.write(b'5')")
+        .run()
+        .await
+        .expect_err("owned quota must reject growth");
+    assert_vfs_quota_rejected(&error);
+    session
+        .execute("with open('/data/file', 'rb') as f:\n    assert f.read() == b'1234'")
+        .run()
+        .await
+        .expect("owned data should survive rejected append");
+    session.reset(&[]).await.expect("reset");
+    let error = session
+        .execute("with open('/data/file', 'ab') as f:\n    f.write(b'5')")
+        .run()
+        .await
+        .expect_err("owned quota must survive reset");
+    assert_vfs_quota_rejected(&error);
+    session
+        .execute("with open('/data/file', 'rb') as f:\n    assert f.read() == b'1234'")
+        .run()
+        .await
+        .expect("owned data should survive reset");
+}


### PR DESCRIPTION
I was using `SandboxFactory` from our custom build and noticed that it can create fresh sandboxes from the preinitialized runtime, but not persistent sessions.

Using `Session()` separately loses the factory's packages and pre-imported state. While bringing this over, I also found a few existing correctness problems in how persistent sessions apply resource limits and mount package directories.

## What is new

- Add `SandboxFactory.create_session()` for creating a persistent session from the factory's preinitialized runtime.
- Support VFS storage, resource limits, networking, callbacks, volumes, output handlers, and result-variable capture.
- Keep extracted package storage alive with the session, so lazy imports continue working after the factory is dropped.
- Apply callback timeout and invocation-count limits to factory sessions.
- Reuse the existing `InstancePreCache` when creating sessions from a factory with `cache=True`.

Factory sessions default to no execution timeout, memory limit, or fuel limit, with the existing 10-second callback timeout and 1000-callback limit. Internally created VFS storage keeps the existing 64 MiB cap.

## Existing behavior kept intact

- The existing `Session()` API and its defaults are unchanged.
- `SandboxFactory.create_sandbox()` is unchanged.
- Session state, `clear_state()`, and full-reset behavior remain the same.
- Timeout and fuel limits remain per execution.
- Caller-provided VFS storage keeps its own quota and policy.
- A full reset still clears Python state while preserving session configuration and VFS data.
- The precompiled artifact format and cache identity are unchanged.
- Synchronous Python callback timeout behavior is unchanged.

## Existing behavior fixed

- Memory limits are now installed before the Wasmtime Store is instantiated, so initial memory growth cannot bypass them.
- Memory, fuel, timeout, and internally owned VFS limits are preserved when a session recreates its Store during reset.
- `InProcessSession` now receives the resource limits configured on its parent `Sandbox`.
- Session callback handlers now receive the configured callback timeout and invocation-count limits.
- The first site-packages directory is mounted at `/site-packages`, matching the path stored in the preinitialized Python `sys.path`.
- Caller-provided VFS storage is no longer accidentally treated as storage whose quota should be controlled by session resource limits.

The site-packages mismatch affected more than the new factory API: package-bearing `InProcessSession`s could also fail to import their packages because they mounted the first directory at `/site-packages-0`.

## Factory-session caching

Before this change, factory sessions deserialized the precompiled component for every new session, even when the factory was loaded with `cache=True`.

Factory sessions now use the existing `PrecompiledArtifact` cache identity and `InstancePreCache`. The first cached session populates the cache, and later sessions reuse the cached `InstancePre`.

In a small local measurement using the same saved factory artifact, creating a session before this change took a median of 53.2 ms. After this change, warm-cache session creation took a median of 1.94 ms, about 27× faster. The first cached call still took 50.5 ms because it populates the cache.

## Compatibility

Previously saved factory artifacts remain compatible. `factory.save()` writes only the precompiled component bytes; it does not store the site-packages mount path or VFS configuration. Those artifacts already have `/site-packages` in the preinitialized Python `sys.path`.

Code that directly relied on the undocumented `/site-packages-0` guest path will need to use `/site-packages`.

Loaded factories still need a valid `site_packages` path when packages that were not pre-imported need to be imported lazily. The package directory itself is not bundled into the saved artifact.

## Follow-ups

I left these as separate work:

- Sharing a Tokio runtime between factory sessions.
- Secret injection and output/file scrubbing for factory sessions.
- Synchronous Python callback teardown after a timeout.
- Persistent-session empty-callback reuse.

## Tests

Added coverage for:

- Factory session state and reset.
- Factory defaults and result capture.
- Memory, fuel, timeout, and callback limits.
- Limit preservation across reset.
- Caller-owned and internally owned VFS storage.
- Custom mount paths and volumes.
- Networking and output handlers.
- Native-extension imports.
- Lazy package imports after dropping the factory.
- Sessions created from a saved-and-loaded factory.
- State isolation between sessions created through the warm cache path.
- Rust `InProcessSession` limit propagation.

Formatting, strict Clippy, and all focused tests pass.