### PR TITLE
feat(preinit): add setup_code to bake arbitrary state into snapshots

### DIFF
--- a/crates/eryx-precompile/src/main.rs
+++ b/crates/eryx-precompile/src/main.rs
@@ -67,7 +67,7 @@ enum Command {
     /// Pre-compile a WASM file to native code (advanced).
     ///
     /// For direct control over pre-initialization and AOT compilation.
-    Compile(CompileArgs),
+    Compile(Box<CompileArgs>),
 }
 
 #[derive(Parser, Debug)]
@@ -163,6 +163,36 @@ struct CompileArgs {
     #[arg(long)]
     no_verify: bool,
 
+    /// Python code to execute during pre-initialization (baked into snapshot)
+    ///
+    /// Runs after imports, before the memory snapshot is taken. Use this to
+    /// pre-create objects that every sandbox should start with (e.g., a Jinja2
+    /// SandboxedEnvironment with filters registered). The state is captured in
+    /// COW memory, so each sandbox gets its own isolated copy.
+    ///
+    /// Mutually exclusive with --setup-file. Requires --preinit.
+    ///
+    /// Example: `--setup-code "from jinja2.sandbox import SandboxedEnvironment; env = SandboxedEnvironment()"`
+    #[arg(
+        long,
+        value_name = "CODE",
+        conflicts_with = "setup_file",
+        requires = "preinit"
+    )]
+    setup_code: Option<String>,
+
+    /// Read setup code from a file instead of inline
+    ///
+    /// Like --setup-code, but reads the Python code from a file. Useful for
+    /// longer setup scripts. Requires --preinit.
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "setup_code",
+        requires = "preinit"
+    )]
+    setup_file: Option<PathBuf>,
+
     /// Python code to execute during verification
     ///
     /// Runs after the standard import verification. Useful for testing that
@@ -190,7 +220,7 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Command::Setup(args) => run_setup(args).await,
-        Command::Compile(args) => run_compile(args).await,
+        Command::Compile(args) => run_compile(*args).await,
     }
 }
 
@@ -410,6 +440,26 @@ async fn run_compile(args: CompileArgs) -> Result<()> {
     if !args.imports.is_empty() {
         println!("Imports: {}", args.imports.join(", "));
     }
+
+    // Resolve setup code from --setup-code or --setup-file
+    let setup_code = if let Some(code) = args.setup_code {
+        Some(code)
+    } else if let Some(ref path) = args.setup_file {
+        let code = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read setup file: {}", path.display()))?;
+        Some(code)
+    } else {
+        None
+    };
+
+    if setup_code.is_some() {
+        println!(
+            "Setup:   {} (baked into snapshot)",
+            args.setup_file
+                .as_ref()
+                .map_or("inline code".to_string(), |p| p.display().to_string())
+        );
+    }
     println!();
 
     // Read input WASM
@@ -459,6 +509,7 @@ async fn run_compile(args: CompileArgs) -> Result<()> {
             final_site_packages.as_deref(),
             &import_refs,
             &extensions,
+            setup_code.as_deref(),
         )
         .await
         .context("Failed to pre-initialize Python")?;

--- a/crates/eryx-python/python/eryx/_eryx.pyi
+++ b/crates/eryx-python/python/eryx/_eryx.pyi
@@ -641,6 +641,7 @@ class SandboxFactory:
         site_packages: Optional[PathLike] = None,
         packages: Optional[Sequence[PathLike]] = None,
         imports: Optional[Sequence[str]] = None,
+        setup_code: Optional[str] = None,
         cache: bool = False,
     ) -> None:
         """Create a new sandbox factory with custom packages.
@@ -654,6 +655,11 @@ class SandboxFactory:
                 These are extracted and their native extensions are linked.
             imports: Optional list of module names to pre-import during initialization.
                 Pre-imported modules are immediately available without import overhead.
+            setup_code: Optional Python code to execute after imports, baked into the
+                snapshot. Use this to pre-create objects (e.g., a Jinja2
+                ``SandboxedEnvironment``) so every sandbox starts with them already
+                in memory. Each sandbox gets its own copy-on-write clone, preserving
+                full isolation.
             cache: Whether to cache the pre-compiled component in the process-global
                 cache. Enabling this computes a BLAKE3 content hash once during
                 factory construction and makes subsequent sandbox creation from an
@@ -670,6 +676,16 @@ class SandboxFactory:
                     "/path/to/markupsafe-2.1.3-wasi.tar.gz",
                 ],
                 imports=["jinja2"],
+            )
+
+            # With setup code baked into the snapshot
+            factory = SandboxFactory(
+                packages=["jinja2.whl", "markupsafe.whl"],
+                imports=["jinja2", "jinja2.sandbox"],
+                setup_code=(
+                    "from jinja2.sandbox import SandboxedEnvironment\\n"
+                    "env = SandboxedEnvironment()\\n"
+                ),
             )
         """
         ...

--- a/crates/eryx-python/src/preinit.rs
+++ b/crates/eryx-python/src/preinit.rs
@@ -95,11 +95,12 @@ impl SandboxFactory {
     ///         imports=["jinja2"],
     ///     )
     #[new]
-    #[pyo3(signature = (*, site_packages=None, packages=None, imports=None, cache=false))]
+    #[pyo3(signature = (*, site_packages=None, packages=None, imports=None, setup_code=None, cache=false))]
     fn new(
         site_packages: Option<PathBuf>,
         packages: Option<Vec<PathBuf>>,
         imports: Option<Vec<String>>,
+        setup_code: Option<String>,
         cache: bool,
     ) -> PyResult<Self> {
         // Create tokio runtime for async pre-initialization
@@ -129,6 +130,7 @@ impl SandboxFactory {
                 final_site_packages.as_deref(),
                 &import_refs,
                 &extensions,
+                setup_code.as_deref(),
             )
             .await
             .map_err(|e| InitializationError::new_err(format!("pre-initialization failed: {e}")))

--- a/crates/eryx-python/tests/test_factory_setup_code.py
+++ b/crates/eryx-python/tests/test_factory_setup_code.py
@@ -1,0 +1,89 @@
+"""Tests for SandboxFactory setup_code parameter."""
+
+import eryx
+import pytest
+
+
+@pytest.fixture(scope="module")
+def setup_factory():
+    """Factory with setup_code that defines variables and functions."""
+    return eryx.SandboxFactory(
+        setup_code=(
+            "setup_value = 42\n"
+            "setup_list = [1, 2, 3]\n"
+            "def setup_add(a, b): return a + b\n"
+        ),
+    )
+
+
+class TestSetupCodeBasic:
+    def test_variable_available(self, setup_factory):
+        sandbox = setup_factory.create_sandbox()
+        result = sandbox.execute("print(setup_value)")
+        assert result.stdout.strip() == "42"
+
+    def test_list_available(self, setup_factory):
+        sandbox = setup_factory.create_sandbox()
+        result = sandbox.execute("print(setup_list)")
+        assert result.stdout.strip() == "[1, 2, 3]"
+
+    def test_function_available(self, setup_factory):
+        sandbox = setup_factory.create_sandbox()
+        result = sandbox.execute("print(setup_add(3, 4))")
+        assert result.stdout.strip() == "7"
+
+
+class TestSetupCodeWithImports:
+    def test_setup_uses_imported_module(self):
+        factory = eryx.SandboxFactory(
+            imports=["json"],
+            setup_code="precomputed = json.dumps({'ready': True})",
+        )
+        sandbox = factory.create_sandbox()
+        result = sandbox.execute("print(precomputed)")
+        assert result.stdout.strip() == '{"ready": true}'
+
+
+class TestSetupCodeIsolation:
+    def test_mutation_does_not_leak(self, setup_factory):
+        # First sandbox: mutate the setup variable
+        sb1 = setup_factory.create_sandbox()
+        sb1.execute("setup_value = 999")
+
+        # Second sandbox: should see original value
+        sb2 = setup_factory.create_sandbox()
+        result = sb2.execute("print(setup_value)")
+        assert result.stdout.strip() == "42"
+
+    def test_list_mutation_does_not_leak(self, setup_factory):
+        sb1 = setup_factory.create_sandbox()
+        sb1.execute("setup_list.append(999)")
+
+        sb2 = setup_factory.create_sandbox()
+        result = sb2.execute("print(len(setup_list))")
+        assert result.stdout.strip() == "3"
+
+
+class TestSetupCodeErrors:
+    def test_syntax_error_raises(self):
+        with pytest.raises(eryx.InitializationError):
+            eryx.SandboxFactory(setup_code="def broken(")
+
+    def test_runtime_error_raises(self):
+        with pytest.raises(eryx.InitializationError):
+            eryx.SandboxFactory(setup_code="raise ValueError('setup failed')")
+
+    def test_import_error_in_setup_raises(self):
+        with pytest.raises(eryx.InitializationError):
+            eryx.SandboxFactory(setup_code="import nonexistent_module_xyz")
+
+
+class TestSetupCodeSaveLoad:
+    def test_setup_state_survives_save_load(self, setup_factory, tmp_path):
+        path = tmp_path / "factory.bin"
+        setup_factory.save(str(path))
+
+        loaded = eryx.SandboxFactory.load(str(path))
+        sandbox = loaded.create_sandbox()
+        result = sandbox.execute("print(setup_value)")
+        assert result.stdout.strip() == "42"

--- a/crates/eryx-runtime/src/preinit.rs
+++ b/crates/eryx-runtime/src/preinit.rs
@@ -31,6 +31,7 @@
 //!     Some(&site_packages_path),
 //!     &["numpy", "pandas"],  // Modules to import during pre-init
 //!     &native_extensions,
+//!     Some("import numpy as np; arr = np.zeros(10)"),  // Optional setup code
 //! ).await?;
 //! ```
 
@@ -40,7 +41,7 @@ use std::path::Path;
 use tempfile::TempDir;
 use wasmtime::{
     Config, Engine, Store,
-    component::{Component, Instance, Linker, ResourceTable, Val},
+    component::{Component, Func, Instance, Linker, ResourceTable, Val},
 };
 use wasmtime_wasi::{FsPerms, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wizer::{WasmtimeWizerComponent, Wizer};
@@ -83,6 +84,9 @@ impl WasiView for PreInitCtx {
 /// * `site_packages` - Optional path to site-packages directory
 /// * `imports` - Modules to import during pre-init (e.g., ["numpy", "pandas"])
 /// * `extensions` - Native extensions to link into the component
+/// * `setup_code` - Optional Python code to execute after imports, baked into
+///   the snapshot. Use this to pre-create objects (e.g., a Jinja2
+///   `SandboxedEnvironment`) so every sandbox starts with them in COW memory.
 ///
 /// # Returns
 ///
@@ -91,12 +95,13 @@ impl WasiView for PreInitCtx {
 /// # Errors
 ///
 /// Returns an error if pre-initialization fails (e.g., Python init error,
-/// import failure).
+/// import failure, or setup code exception).
 pub async fn pre_initialize(
     python_stdlib: &Path,
     site_packages: Option<&Path>,
     imports: &[&str],
     extensions: &[NativeExtension],
+    setup_code: Option<&str>,
 ) -> Result<Vec<u8>> {
     let imports: Vec<String> = imports.iter().map(|s| (*s).to_string()).collect();
 
@@ -185,6 +190,12 @@ pub async fn pre_initialize(
     // If imports are specified, call execute() to import them
     if !imports.is_empty() {
         call_execute_for_imports(&mut store, &instance, &imports).await?;
+    }
+
+    // If setup code is provided, execute it after imports so its state
+    // (variables, objects, etc.) gets captured in the Wizer snapshot.
+    if let Some(code) = setup_code {
+        call_execute_code(&mut store, &instance, code, "setup code").await?;
     }
 
     // CRITICAL: Call finalize-preinit to reset WASI state AFTER all imports.
@@ -712,16 +723,63 @@ async fn call_execute_for_imports(
     instance: &Instance,
     imports: &[String],
 ) -> Result<()> {
-    // Find the execute function.
-    // Our WIT exports functions directly, not in an "exports" interface.
-    // Try direct export first, then fall back to exports interface.
-    let execute_func = if let Some(func) = instance.get_func(&mut *store, "execute") {
-        func
+    let import_code = imports
+        .iter()
+        .map(|module| format!("import {module}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    call_execute_code(store, instance, &import_code, "imports").await
+}
+
+/// Call the execute export with arbitrary Python code during pre-init.
+///
+/// The `label` is used in error messages to identify what kind of code failed
+/// (e.g., "imports", "setup code").
+async fn call_execute_code(
+    store: &mut Store<PreInitCtx>,
+    instance: &Instance,
+    code: &str,
+    label: &str,
+) -> Result<()> {
+    let execute_func = find_execute_func(store, instance)?;
+
+    let args = [Val::String(code.to_string())];
+    let mut results = vec![Val::Bool(false)];
+
+    execute_func
+        .call_async(&mut *store, &args, &mut results)
+        .await
+        .map_err(|e| e.context(format!("Failed to execute {label} during pre-init")))?;
+
+    match &results[0] {
+        Val::Result(Ok(_)) => Ok(()),
+        Val::Result(Err(Some(error_val))) => {
+            let error_msg = match error_val.as_ref() {
+                Val::String(s) => s.clone(),
+                other => format!("unexpected error value: {other:?}"),
+            };
+            Err(anyhow!(
+                "Pre-init {label} execution failed: {error_msg}\nCode:\n{code}"
+            ))
+        }
+        Val::Result(Err(None)) => Err(anyhow!(
+            "Pre-init {label} execution failed with unknown error\nCode:\n{code}"
+        )),
+        other => {
+            tracing::warn!("Unexpected result type from execute during pre-init: {other:?}");
+            Ok(())
+        }
+    }
+}
+
+/// Find the `execute` export function on the WASM instance.
+fn find_execute_func(store: &mut Store<PreInitCtx>, instance: &Instance) -> Result<Func> {
+    if let Some(func) = instance.get_func(&mut *store, "execute") {
+        Ok(func)
     } else if let Some(func) = instance.get_func(&mut *store, "[async]execute") {
-        // Async exports may have [async] prefix
-        func
+        Ok(func)
     } else {
-        // Try looking in an "exports" interface (for compatibility)
         let (_item, exports_idx) = instance
             .get_export(&mut *store, None, "exports")
             .ok_or_else(|| anyhow!("No 'exports' or 'execute' export found"))?;
@@ -732,52 +790,7 @@ async fn call_execute_for_imports(
 
         instance
             .get_func(&mut *store, execute_idx)
-            .ok_or_else(|| anyhow!("Could not get execute func from index"))?
-    };
-
-    // Generate import code
-    let import_code = imports
-        .iter()
-        .map(|module| format!("import {module}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    // Call execute with the import code
-    let args = [Val::String(import_code.clone())];
-    // Result placeholder - wasmtime will fill this with Val::Result
-    let mut results = vec![Val::Bool(false)];
-
-    execute_func
-        .call_async(&mut *store, &args, &mut results)
-        .await
-        .map_err(|e| e.context("Failed to execute imports during pre-init"))?;
-
-    // Check if the result was an error
-    // result<string, string> is represented as Val::Result(Result<Option<Box<Val>>, Option<Box<Val>>>)
-    match &results[0] {
-        Val::Result(Ok(_)) => {
-            // Success - imports completed
-            Ok(())
-        }
-        Val::Result(Err(Some(error_val))) => {
-            // Error - extract the error message
-            let error_msg = match error_val.as_ref() {
-                Val::String(s) => s.clone(),
-                other => format!("unexpected error value: {other:?}"),
-            };
-            Err(anyhow!(
-                "Pre-init import execution failed: {error_msg}\nImport code:\n{import_code}"
-            ))
-        }
-        Val::Result(Err(None)) => Err(anyhow!(
-            "Pre-init import execution failed with unknown error\nImport code:\n{import_code}"
-        )),
-        other => {
-            // Unexpected result type - log warning but don't fail
-            // This shouldn't happen, but be defensive
-            tracing::warn!("Unexpected result type from execute during pre-init: {other:?}");
-            Ok(())
-        }
+            .ok_or_else(|| anyhow!("Could not get execute func from index"))
     }
 }
 

--- a/crates/eryx/examples/jinja2_sandbox.rs
+++ b/crates/eryx/examples/jinja2_sandbox.rs
@@ -81,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
         Some(&site_packages),
         &["jinja2"], // Pre-import jinja2 during init
         &extensions,
+        None,
     )
     .await?;
     println!(

--- a/crates/eryx/examples/memory_bench.rs
+++ b/crates/eryx/examples/memory_bench.rs
@@ -269,6 +269,7 @@ async fn run_numpy_benchmark() -> Result<(), Box<dyn std::error::Error>> {
         Some(site_packages),
         &["numpy"],
         &native_extensions,
+        None,
     )
     .await?;
     println!("  Pre-init in {:?}", start.elapsed());

--- a/crates/eryx/examples/numpy_preinit.rs
+++ b/crates/eryx/examples/numpy_preinit.rs
@@ -119,6 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(site_packages),
         &["numpy"], // Pre-import numpy during init
         &native_extensions,
+        None,
     )
     .await?;
 

--- a/crates/eryx/examples/precompile.rs
+++ b/crates/eryx/examples/precompile.rs
@@ -115,6 +115,7 @@ fn main() -> anyhow::Result<()> {
                 None, // No site-packages for base runtime
                 &[],  // No imports for base runtime
                 &[],  // No native extensions for base runtime
+                None, // No setup code
             )
             .await
         })?;

--- a/crates/eryx/tests/preinit.rs
+++ b/crates/eryx/tests/preinit.rs
@@ -123,7 +123,7 @@ async fn shared_preinit(stdlib: &Path, imports: &[&str]) -> Arc<Vec<u8>> {
         Arc::new(bytes)
     } else {
         let bytes = Arc::new(
-            pre_initialize(stdlib, None, imports, &[])
+            pre_initialize(stdlib, None, imports, &[], None)
                 .await
                 .expect("pre-initialization should succeed"),
         );
@@ -390,4 +390,121 @@ print(f"has_encodings: {'encodings' in files}")
         .unwrap();
 
     assert!(result.stdout.contains("has_encodings: True"));
+}
+
+// =============================================================================
+// Setup Code Tests
+// =============================================================================
+
+/// Test that setup_code runs during pre-init and state is available in sandboxes.
+#[tokio::test]
+async fn preinit_setup_code_defines_variable() {
+    let stdlib = get_stdlib_path();
+
+    let preinit_bytes = pre_initialize(
+        &stdlib,
+        None,
+        &[],
+        &[],
+        Some("setup_value = 42\nsetup_list = [1, 2, 3]"),
+    )
+    .await
+    .expect("pre-initialization with setup code should succeed");
+
+    let sandbox = Sandbox::builder()
+        .with_wasm_bytes(preinit_bytes)
+        .with_python_stdlib(&stdlib)
+        .build()
+        .expect("sandbox creation should succeed");
+
+    let result = sandbox
+        .execute("print(f'{setup_value} {setup_list}')")
+        .await
+        .expect("execution should succeed");
+
+    assert!(result.stdout.contains("42 [1, 2, 3]"));
+}
+
+/// Test that setup_code runs after imports, so imported modules are available.
+#[tokio::test]
+async fn preinit_setup_code_uses_imports() {
+    let stdlib = get_stdlib_path();
+
+    let preinit_bytes = pre_initialize(
+        &stdlib,
+        None,
+        &["json"],
+        &[],
+        Some("precomputed = json.dumps({'ready': True})"),
+    )
+    .await
+    .expect("pre-initialization with imports + setup code should succeed");
+
+    let sandbox = Sandbox::builder()
+        .with_wasm_bytes(preinit_bytes)
+        .with_python_stdlib(&stdlib)
+        .build()
+        .expect("sandbox creation should succeed");
+
+    let result = sandbox
+        .execute("print(precomputed)")
+        .await
+        .expect("execution should succeed");
+
+    assert!(result.stdout.contains(r#"{"ready": true}"#));
+}
+
+/// Test that setup_code state is isolated between sandboxes (COW).
+#[tokio::test]
+async fn preinit_setup_code_isolated_between_sandboxes() {
+    let stdlib = get_stdlib_path();
+
+    let preinit_bytes = pre_initialize(&stdlib, None, &[], &[], Some("counter = 0"))
+        .await
+        .expect("pre-initialization should succeed");
+
+    // First sandbox: mutate the variable
+    let sandbox1 = Sandbox::builder()
+        .with_wasm_bytes(preinit_bytes.clone())
+        .with_python_stdlib(&stdlib)
+        .build()
+        .unwrap();
+
+    sandbox1
+        .execute("counter += 100\nprint(f'sb1: {counter}')")
+        .await
+        .unwrap();
+
+    // Second sandbox: should see the original value, not the mutated one
+    let sandbox2 = Sandbox::builder()
+        .with_wasm_bytes(preinit_bytes)
+        .with_python_stdlib(&stdlib)
+        .build()
+        .unwrap();
+
+    let result = sandbox2.execute("print(f'sb2: {counter}')").await.unwrap();
+
+    assert!(result.stdout.contains("sb2: 0"));
+}
+
+/// Test that setup_code errors are reported clearly.
+#[tokio::test]
+async fn preinit_setup_code_error_is_reported() {
+    let stdlib = get_stdlib_path();
+
+    let result = pre_initialize(
+        &stdlib,
+        None,
+        &[],
+        &[],
+        Some("raise ValueError('setup failed')"),
+    )
+    .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("setup code"),
+        "error should mention 'setup code': {err}"
+    );
 }


### PR DESCRIPTION
## Summary

- Add `setup_code` parameter to `pre_initialize()` — executes arbitrary Python code after imports but before the Wizer memory snapshot, baking the result into the COW image
- Expose via `SandboxFactory(setup_code="...")` in Python bindings and `--setup-code` / `--setup-file` in the precompile CLI
- Refactor preinit execute path into shared `call_execute_code` helper to avoid duplication

## Motivation

Consumers using `SandboxFactory` for template rendering (e.g., Jinja2) already pre-import modules via the factory's `imports` parameter, but each `sandbox.execute()` still re-executes significant Python setup (environment creation, filter registration, helper definitions) on every request. For short-lived sandboxes this setup dominates latency.

With `setup_code`, that setup runs once during pre-initialization and gets baked into the snapshot. Each sandbox starts with the pre-created objects already in COW memory — full tenant isolation preserved, per-request work reduced to just the payload-specific logic.

## API

**Python:**
```python
factory = SandboxFactory(
    packages=["jinja2.whl", "markupsafe.whl"],
    imports=["jinja2", "jinja2.sandbox"],
    setup_code=(
        "from jinja2.sandbox import SandboxedEnvironment\n"
        "env = SandboxedEnvironment()\n"
    ),
)
# Every sandbox starts with `env` already defined
sandbox = factory.create_sandbox()
result = sandbox.execute('print(env.from_string("{{ x }}").render(x=42))')
```

**CLI:**
```bash
eryx-precompile compile runtime.wasm -o runtime.cwasm --preinit \
  --stdlib ./python-stdlib \
  --package jinja2.whl --import jinja2 \
  --setup-code "from jinja2.sandbox import SandboxedEnvironment; env = SandboxedEnvironment()"

# Or from a file for longer setup scripts:
eryx-precompile compile runtime.wasm -o runtime.cwasm --preinit \
  --stdlib ./python-stdlib \
  --setup-file setup.py
```

## Test plan

- [x] Rust: 4 new preinit tests (variable definition, imports+setup interaction, COW isolation, error reporting)
- [x] Python: 10 new tests (basic usage, imports+setup, isolation, error cases, save/load roundtrip)
- [x] All 12 existing preinit tests pass
- [x] All 12 existing `TestSandboxFactory` tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)