### PR TITLE
docs: document setup_code for SandboxFactory and precompile CLI

### DIFF
--- a/book/src/guide/precompile.md
+++ b/book/src/guide/precompile.md
@@ -121,6 +121,33 @@ eryx-precompile compile runtime.wasm -o runtime.cwasm \
 
 Supported package formats: `.whl`, `.tar.gz`, and directories. Native extensions (`.so` files) are detected and linked automatically.
 
+### Setup Code
+
+Beyond importing modules, you can execute arbitrary Python code during pre-initialization. The resulting state (variables, objects, environments) is captured in the memory snapshot — each sandbox starts with that state in copy-on-write memory, preserving full isolation.
+
+This is useful when your sandboxes all need the same expensive setup that doesn't change between requests:
+
+```bash
+# Bake a Jinja2 SandboxedEnvironment with custom filters into the snapshot
+eryx-precompile compile runtime.wasm -o jinja2.cwasm \
+  --preinit --stdlib ./python-stdlib \
+  --package jinja2.whl --package markupsafe.whl \
+  --import jinja2 --import jinja2.sandbox \
+  --setup-code "
+from jinja2.sandbox import SandboxedEnvironment
+env = SandboxedEnvironment()
+"
+
+# For longer setup scripts, use --setup-file
+eryx-precompile compile runtime.wasm -o jinja2.cwasm \
+  --preinit --stdlib ./python-stdlib \
+  --package jinja2.whl --package markupsafe.whl \
+  --import jinja2 \
+  --setup-file setup.py
+```
+
+Each sandbox created from the resulting artifact starts with `env` already defined. Per-request code only needs to handle the request-specific work (deserializing data, compiling the template, rendering).
+
 ### Verification
 
 By default, `compile` verifies the output by creating a test sandbox. You can add custom verification:

--- a/crates/eryx-python/README.md
+++ b/crates/eryx-python/README.md
@@ -438,6 +438,7 @@ Use cases for `SandboxFactory`:
 
 - Load packages (jinja2, numpy, etc.) once and create many sandboxes from the factory
 - Pre-import modules to eliminate import overhead on first execution
+- Pre-execute setup code (environment creation, filter registration) baked into the snapshot
 - Save/load factory state to disk for persistence across process restarts
 
 ```python
@@ -464,6 +465,40 @@ for i in range(100):
     sandbox = factory.create_sandbox()
     sandbox.execute(f"print('Sandbox {i}')")
 ```
+
+#### Setup Code
+
+Beyond pre-importing modules, you can run arbitrary Python code during factory
+construction. The resulting state is captured in the memory snapshot — each
+sandbox starts with it in copy-on-write memory, preserving full isolation.
+
+```python
+factory = eryx.SandboxFactory(
+    packages=["jinja2.whl", "markupsafe.whl"],
+    imports=["jinja2", "jinja2.sandbox"],
+    setup_code="""
+from jinja2.sandbox import SandboxedEnvironment
+
+def my_filter(value):
+    return value.upper()
+
+env = SandboxedEnvironment()
+env.filters['shout'] = my_filter
+""",
+)
+
+# Every sandbox starts with `env` and `my_filter` already defined
+sandbox = factory.create_sandbox()
+result = sandbox.execute('''
+template = env.from_string("{{ name | shout }}")
+print(template.render(name="world"))
+''')
+print(result.stdout)  # "WORLD"
+```
+
+This reduces per-sandbox execution time by avoiding repeated setup work. The
+factory build cost (one-time) is negligibly higher since the setup code runs
+during pre-initialization.
 
 #### Saving and Loading
 


### PR DESCRIPTION
## Summary

Document the `setup_code` feature added in #397.

- **Python README** (`crates/eryx-python/README.md`): new "Setup Code" section under `SandboxFactory` with example showing a pre-baked Jinja2 environment with custom filters
- **Precompile guide** (`book/src/guide/precompile.md`): new "Setup Code" section covering `--setup-code` and `--setup-file` CLI flags

## Test plan

- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)