### PR TITLE
fix(ci): add rust-toolchain.toml for cargo-dist release builds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -340,6 +340,23 @@
     },
 
     // ------------------------------------------------------------------
+    // rust-toolchain.toml channel pin. cargo-dist runners (and any CI
+    // that doesn't use mise) read this to install the right Rust via
+    // rustup. Same dep identity as the Cargo.toml MSRV manager above
+    // so both land in the "Rust toolchain" group.
+    // ------------------------------------------------------------------
+    {
+      customType: "regex",
+      managerFilePatterns: ["/rust-toolchain\\.toml$/"],
+      matchStrings: [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+      ],
+      depNameTemplate: "rust",
+      datasourceTemplate: "docker",
+      versioningTemplate: "semver",
+    },
+
+    // ------------------------------------------------------------------
     // The MSRV job pins its toolchain in an inline mise config passed to
     // jdx/mise-action (`mise_toml: |`). The github-actions manager only
     // reads `uses:`, and the mise manager only reads mise.toml files, so

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.98.1"


### PR DESCRIPTION
## Summary

- Add `rust-toolchain.toml` pinning `channel = "1.98.1"` so cargo-dist CI runners auto-install the right Rust version via rustup
- Add Renovate custom manager for `rust-toolchain.toml` so it stays in the "Rust toolchain" group alongside `Cargo.toml` rust-version, `mise.toml`, and Docker base images

## Problem

The cargo-dist release workflow ([run #34461039682](https://github.com/eryx-org/eryx/actions/runs/34461039682)) failed on macOS and aarch64-linux because the runners had Rust 1.98.0 preinstalled but `rust-version = "1.98.1"` in Cargo.toml:

```
error: rustc 1.98.0 is not supported by the following packages:
  eryx@0.7.0 requires rustc 1.98.1
```

## Fix

`rust-toolchain.toml` is the standard mechanism — `rustup` reads it and installs the specified version automatically. This only affects rustup-based environments (cargo-dist CI); mise-based workflows continue using `mise.toml`.

The Renovate custom manager ensures future Rust toolchain bumps update all four version pins in one PR:
- `Cargo.toml` → `rust-version`
- `mise.toml` → `rust` tool version
- `rust-toolchain.toml` → `channel` (new)
- CI workflow inline mise configs

## Test plan

- [x] Existing CI unaffected (uses mise, not rust-toolchain.toml)
- [ ] Re-run the failed eryx-precompile release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)