### PR TITLE
fix: normalize native extension dlopen paths on Windows

### DIFF
--- a/crates/eryx-precompile/src/main.rs
+++ b/crates/eryx-precompile/src/main.rs
@@ -646,7 +646,12 @@ fn process_packages(
                 let relative = path
                     .strip_prefix(site_pkg_path)
                     .context("Failed to compute relative path")?;
-                let dlopen_path = format!("/site-packages/{}", relative.display());
+                let relative_str = relative
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                let dlopen_path = format!("/site-packages/{relative_str}");
 
                 // Skip if we already have this extension from packages
                 if extensions.iter().any(|e| e.name == dlopen_path) {

--- a/crates/eryx-python/src/preinit.rs
+++ b/crates/eryx-python/src/preinit.rs
@@ -534,7 +534,12 @@ fn process_packages(
                 let relative = path.strip_prefix(site_pkg_path).map_err(|e| {
                     InitializationError::new_err(format!("failed to get relative path: {e}"))
                 })?;
-                let dlopen_path = format!("/site-packages/{}", relative.display());
+                let relative_str = relative
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                let dlopen_path = format!("/site-packages/{relative_str}");
 
                 // Skip if we already have this extension from packages
                 if extensions.iter().any(|e| e.name == dlopen_path) {

--- a/crates/eryx/src/package.rs
+++ b/crates/eryx/src/package.rs
@@ -360,7 +360,11 @@ impl ExtractedPackage {
                     Error::Initialization(format!("Failed to compute relative path: {e}"))
                 })?;
 
-                let relative_path = relative.display().to_string();
+                let relative_path = relative
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
 
                 let bytes = std::fs::read(path)
                     .map_err(|e| Error::Initialization(format!("Failed to read .so file: {e}")))?;


### PR DESCRIPTION
## Summary

Fix Windows CI failure in `test_factory_session_volumes_output_and_native_import` — native extension import fails with `ImportError: library not found`.

## Root cause

`ExtractedPackage::scan_for_extensions` (package.rs:363) used `relative.display()` to build native extension relative paths. On Windows, this produces backslashes (`markupsafe\_speedups.cpython-314-wasm32-wasi.so`). These paths are used as WASI dlopen paths inside the sandbox guest, which expects forward slashes.

The mismatch only manifests when importing native extensions at **runtime** (not during preinit). When `imports=["jinja2"]` is specified, the import happens during preinit before the path is checked at runtime, masking the bug. The new factory session test uses `imports=[]`, exposing it.

## Fix

Normalize path separators to forward slashes using `Path::components()` + `join("/")` in all three sites that construct dlopen paths from host filesystem paths:

- `crates/eryx/src/package.rs` — `scan_for_extensions` (root cause)
- `crates/eryx-python/src/preinit.rs` — `process_packages` site-packages scan
- `crates/eryx-precompile/src/main.rs` — `process_packages` site-packages scan

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Windows CI passes (the failing test should now pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)