### PR TITLE
ci: add Windows Python bindings test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,12 @@ jobs:
           touch crates/eryx-runtime/runtime.wasm
           touch crates/eryx-runtime/prebuilt/*
 
+      - name: Set up Python stdlib for preinit
+        shell: bash
+        run: |
+          mkdir -p crates/eryx-wasm-runtime/tests/python-stdlib
+          tar -xf crates/eryx/python-stdlib.tar.zst -C crates/eryx-wasm-runtime/tests/
+
       - name: Install Rust
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,79 @@ jobs:
           echo "=== resource_limits.py ==="
           python examples/resource_limits.py
 
+  # Test Python bindings on Windows so platform-specific failures (path
+  # separators, temp-dir cleanup, native extension loading) are caught before
+  # the release workflow, which is the only other place Windows tests run.
+  python-bindings-windows:
+    name: Python Bindings (Windows)
+    runs-on: windows-latest
+    needs: [changes, build-eryx-runtime]
+    if: >-
+      github.event_name == 'push'
+      || needs.changes.outputs.core == 'true'
+      || needs.changes.outputs.python == 'true'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-runtime
+          path: crates/
+
+      - name: Mark WASM artifacts as current
+        shell: bash
+        run: |
+          touch crates/eryx-runtime/runtime.wasm
+          touch crates/eryx-runtime/prebuilt/*
+
+      - name: Install Rust
+        shell: bash
+        run: |
+          RUST_VERSION=$(sed -n 's/^rust = { version = "\([^"]*\)".*/\1/p' mise.toml)
+          if [ -z "$RUST_VERSION" ]; then
+            echo "could not read the rust pin from mise.toml" >&2
+            exit 1
+          fi
+          rustup toolchain install "$RUST_VERSION" --profile minimal
+          rustup default "$RUST_VERSION"
+
+      - name: Configure Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Pre-compile WASM for Windows
+        shell: bash
+        run: |
+          cargo run -p eryx --example precompile --features preinit --release
+          touch crates/eryx-runtime/runtime.cwasm
+        env:
+          ERYX_PRECOMPILE_BOOTSTRAP: "1"
+          ERYX_CPU_FEATURES: "x86-64-v2"
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - name: Build and install eryx-python with dev dependencies
+        shell: bash
+        working-directory: crates/eryx-python
+        run: |
+          uv venv ../../.venv
+          source ../../.venv/Scripts/activate
+          uv pip install maturin
+          maturin develop --release
+          uv export --extra dev --no-dev --no-hashes --no-emit-project --frozen | uv pip install -r -
+
+      - name: Run Python tests
+        shell: bash
+        working-directory: crates/eryx-python
+        run: |
+          source ../../.venv/Scripts/activate
+          pytest tests/ -v
+
   # Test book examples
   book-tests:
     name: Book Tests


### PR DESCRIPTION
## Summary

Add a `python-bindings-windows` CI job that builds and tests the Python bindings on `windows-latest`.

## Motivation

The existing `platform-check` job only runs `cargo check --exclude eryx-python` on Windows/macOS, so Python test failures on Windows are only caught at release time in the `Python Release` workflow. This is how the path separator bug (#405) slipped through — `test_factory_session_volumes_output_and_native_import` failed on Windows but was never run in CI.

## What it does

Mirrors the existing Linux `python-bindings` job:
1. Downloads WASM artifacts from the `build-eryx-runtime` job
2. Pre-compiles WASM for Windows (with `ERYX_CPU_FEATURES=x86-64-v2`)
3. Builds the Python extension with maturin
4. Runs `pytest tests/ -v`

Uses the same path-filter triggers as the Linux job (`core == 'true'` or `python == 'true'`), so it only runs when relevant files change.

## Test plan

- [ ] CI passes on this PR (the new job should run and pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)