### PR TITLE
feat!(python): default SandboxFactory cache to True

### DIFF
--- a/book/src/guide/sandboxes.md
+++ b/book/src/guide/sandboxes.md
@@ -260,7 +260,7 @@ factory = eryx.SandboxFactory()
 
 print(f"Factory size: {factory.size_bytes} bytes")
 
-# Create sandboxes quickly from the factory (~16ms each)
+# Create sandboxes quickly from the factory (~1ms each)
 for i in range(5):
     sandbox = factory.create_sandbox()
     result = sandbox.execute(f"print('sandbox {i}')")

--- a/crates/eryx-python/README.md
+++ b/crates/eryx-python/README.md
@@ -155,7 +155,7 @@ factory = eryx.SandboxFactory(
     imports=["jinja2"],  # Optional: pre-import for faster first execution
 )
 
-# Create sandboxes with packages already loaded (~10-20ms each)
+# Create sandboxes with packages already loaded (~1ms each)
 sandbox = factory.create_sandbox()
 result = sandbox.execute('''
 from jinja2 import Template
@@ -453,7 +453,7 @@ factory = eryx.SandboxFactory(
     imports=["jinja2"],  # Pre-import modules
 )
 
-# Create sandboxes with packages already loaded (~10-20ms each)
+# Create sandboxes with packages already loaded (~1ms each)
 sandbox = factory.create_sandbox()
 result = sandbox.execute('''
 from jinja2 import Template

--- a/crates/eryx-python/examples/jinja2_factory.py
+++ b/crates/eryx-python/examples/jinja2_factory.py
@@ -6,7 +6,7 @@ Demonstrates sandboxed Jinja2 template evaluation using eryx with
 SandboxFactory for fast sandbox creation with packages.
 
 This is similar to jinja2_sandbox.py but uses SandboxFactory
-to achieve ~10-20ms sandbox creation instead of ~700ms.
+to achieve ~1ms sandbox creation instead of ~700ms.
 
 Prerequisites:
     # Download jinja2 (pure Python)
@@ -197,7 +197,7 @@ print(f"HOME env var: {home}")
     print()
     print("  Key benefits:")
     print("    - Pre-import expensive modules (jinja2) once")
-    print("    - Create sandboxes in ~10-20ms instead of ~700ms")
+    print("    - Create sandboxes in ~1ms instead of ~700ms")
     print("    - Save/load factory for fast startup across processes")
     print("    - Full isolation: each sandbox is independent")
 

--- a/crates/eryx-python/python/eryx/_eryx.pyi
+++ b/crates/eryx-python/python/eryx/_eryx.pyi
@@ -642,12 +642,12 @@ class SandboxFactory:
         packages: Optional[Sequence[PathLike]] = None,
         imports: Optional[Sequence[str]] = None,
         setup_code: Optional[str] = None,
-        cache: bool = False,
+        cache: bool = True,
     ) -> None:
         """Create a new sandbox factory with custom packages.
 
         This performs one-time initialization that can take 3-5 seconds,
-        but subsequent sandbox creation will be very fast (~10-20ms).
+        but subsequent sandbox creation will be very fast.
 
         Args:
             site_packages: Optional path to a directory containing Python packages.
@@ -661,9 +661,10 @@ class SandboxFactory:
                 in memory. Each sandbox gets its own copy-on-write clone, preserving
                 full isolation.
             cache: Whether to cache the pre-compiled component in the process-global
-                cache. Enabling this computes a BLAKE3 content hash once during
-                factory construction and makes subsequent sandbox creation from an
-                equivalent artifact avoid deserialization. Defaults to False.
+                cache. When enabled, a BLAKE3 content hash is computed once during
+                factory construction and subsequent ``create_sandbox()`` calls skip
+                component deserialization entirely (~0.8ms vs ~8ms per call).
+                Defaults to True.
 
         Raises:
             InitializationError: If initialization fails.
@@ -695,7 +696,7 @@ class SandboxFactory:
         path: PathLike,
         *,
         site_packages: Optional[PathLike] = None,
-        cache: bool = False,
+        cache: bool = True,
     ) -> SandboxFactory:
         """Load a sandbox factory from a file.
 
@@ -707,8 +708,9 @@ class SandboxFactory:
             site_packages: Optional path to site-packages directory.
                 Required if the factory was saved without embedded packages.
             cache: Whether to cache the pre-compiled component in the process-global
-                cache. Enabling this computes a BLAKE3 content hash once during
-                loading. Defaults to False.
+                cache. When enabled, a BLAKE3 content hash is computed once during
+                loading and subsequent ``create_sandbox()`` calls skip component
+                deserialization entirely (~0.8ms vs ~8ms per call). Defaults to True.
 
         Returns:
             A SandboxFactory loaded from the file.

--- a/crates/eryx-python/src/preinit.rs
+++ b/crates/eryx-python/src/preinit.rs
@@ -32,7 +32,7 @@ use crate::session::Session;
 ///         imports=["jinja2"],
 ///     )
 ///
-///     # Create sandboxes with packages already loaded (~10-20ms each)
+///     # Create sandboxes with packages already loaded (~1ms each)
 ///     sandbox = factory.create_sandbox()
 ///     result = sandbox.execute('from jinja2 import Template; print(Template("{{ x }}").render(x=42))')
 ///
@@ -68,7 +68,7 @@ impl SandboxFactory {
     /// Create a new sandbox factory with custom packages.
     ///
     /// This performs one-time initialization that can take 3-5 seconds,
-    /// but subsequent sandbox creation will be very fast (~10-20ms).
+    /// but subsequent sandbox creation will be very fast (~1ms).
     ///
     /// Args:
     ///     site_packages: Optional path to a directory containing Python packages.
@@ -77,9 +77,10 @@ impl SandboxFactory {
     ///     imports: Optional list of module names to pre-import during initialization.
     ///         Pre-imported modules are immediately available without import overhead.
     ///     cache: Whether to cache the pre-compiled component in the process-global
-    ///         cache. Enabling this computes a BLAKE3 content hash once during
-    ///         factory construction and makes subsequent sandbox creation from an
-    ///         equivalent artifact avoid deserialization. Defaults to False.
+    ///         cache. When enabled, a BLAKE3 content hash is computed once during
+    ///         factory construction and subsequent ``create_sandbox()`` calls skip
+    ///         component deserialization entirely (~0.8ms vs ~8ms per call).
+    ///         Defaults to True.
     ///
     /// Returns:
     ///     A SandboxFactory ready to create sandboxes with packages.
@@ -97,7 +98,7 @@ impl SandboxFactory {
     ///         imports=["jinja2"],
     ///     )
     #[new]
-    #[pyo3(signature = (*, site_packages=None, packages=None, imports=None, setup_code=None, cache=false))]
+    #[pyo3(signature = (*, site_packages=None, packages=None, imports=None, setup_code=None, cache=true))]
     fn new(
         site_packages: Option<PathBuf>,
         packages: Option<Vec<PathBuf>>,
@@ -159,8 +160,9 @@ impl SandboxFactory {
     /// Args:
     ///     path: Path to the saved factory file.
     ///     cache: Whether to cache the pre-compiled component in the process-global
-    ///         cache. Enabling this computes a BLAKE3 content hash once during
-    ///         loading. Defaults to False.
+    ///         cache. When enabled, a BLAKE3 content hash is computed once during
+    ///         loading and subsequent ``create_sandbox()`` calls skip component
+    ///         deserialization entirely (~0.8ms vs ~8ms per call). Defaults to True.
     ///
     /// Returns:
     ///     A SandboxFactory loaded from the file.
@@ -172,7 +174,7 @@ impl SandboxFactory {
     ///     factory = SandboxFactory.load("/path/to/jinja2-factory.bin")
     ///     sandbox = factory.create_sandbox()
     #[staticmethod]
-    #[pyo3(signature = (path, *, site_packages=None, cache=false))]
+    #[pyo3(signature = (path, *, site_packages=None, cache=true))]
     fn load(path: PathBuf, site_packages: Option<PathBuf>, cache: bool) -> PyResult<Self> {
         // Get embedded resources for stdlib path
         let embedded = eryx::embedded::EmbeddedResources::get().map_err(eryx_error_to_py)?;
@@ -309,7 +311,7 @@ impl SandboxFactory {
 
     /// Create a new sandbox from this factory.
     ///
-    /// This is fast (~10-20ms) because the packages are already bundled
+    /// This is fast (~1ms) because the packages are already bundled
     /// into the factory's snapshot.
     ///
     /// Args:


### PR DESCRIPTION
## Summary

- Default the `cache` parameter on `SandboxFactory.__init__()` and `SandboxFactory.load()` from `False` to `True`
- This enables the process-global `InstancePreCache`, which avoids re-deserializing the precompiled component on every `create_sandbox()` call
- Update docs and examples to reflect the new ~1ms creation time

## Benchmarks

With a ~47MB Jinja2 factory (50 iterations, release pyeryx):

| Operation | `cache=False` (old default) | `cache=True` (new default) | Speedup |
|---|---|---|---|
| `create_sandbox()` | 8.07ms | 0.80ms | **10x** |
| `create_sandbox()` + `execute(render)` | 19.62ms | 5.89ms | **3.3x** |

The only cost of `cache=True` is a one-time BLAKE3 hash computation over the precompiled bytes during factory construction (~1ms for a 47MB artifact). Subsequent `create_sandbox()` calls skip `Component::deserialize` entirely by reusing the cached `InstancePre`.

## Breaking change

This is technically a default-change: callers that relied on `cache=False` (e.g., to avoid the hash computation or to test uncached paths) will need to pass `cache=False` explicitly. In practice, `cache=True` is strictly better for all production use cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)