### PR TITLE
chore(mise): pin rust to 1.98.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Profile "default" includes rustc, rust-std, cargo, rust-docs, rustfmt, and clippy
-rust = { version = "1.98", profile = "default" }
+rust = { version = "1.98.1", profile = "default" }
 
 [tools."cargo:cargo-nextest"]
 version = "0.9.143"


### PR DESCRIPTION
## Summary

`mise.toml` asked for rust `"1.98"`, which rustup had installed as 1.98.0, while `rust-toolchain.toml` (#404) and the workspace `rust-version` require 1.98.1. Every cargo invocation through the mise shim failed with `rustc 1.98.0 is not supported` until the toolchain was overridden by hand.

This pins mise to 1.98.1 so all three agree. (1.98.1 is the current stable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)